### PR TITLE
fix(build): Specify wasm-bindgen version in Trunk.toml

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,5 +1,6 @@
 [build]
 target = "./index.html"
+wasm-bindgen = "0.2.92"
 
 [watch]
 ignore = ["./src-tauri"]


### PR DESCRIPTION
The build was failing due to a network error when downloading the wasm-bindgen CLI. This is often caused by Trunk trying to fetch an incompatible or unavailable version.

This change explicitly sets the wasm-bindgen version to "0.2.92" in Trunk.toml to ensure a stable, known-good version is used, resolving the download failure.