### PR TITLE
fix(tray): show tray icon on macOS by setting explicit PNG and enabli…

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 
 [dev-dependencies]

--- a/src-tauri/Info.plist.in
+++ b/src-tauri/Info.plist.in
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use tauri::{
+    image::Image,
     menu::{Menu, MenuItem},
     tray::{TrayIconBuilder, TrayIconEvent},
     Manager,
@@ -17,9 +18,14 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
+            // 明示的にトレイアイコンを設定（macOS では必須）。
+            let tray_icon = Image::from_bytes(include_bytes!("../icons/32x32.png"))
+                .expect("failed to load tray icon");
             let quit_item = MenuItem::with_id(app, TRAY_QUIT_ID, "Quit", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&quit_item])?;
             TrayIconBuilder::new()
+                .icon(tray_icon)
+                .icon_as_template(true)
                 .menu(&menu)
                 .tooltip("Time Wise")
                 .on_menu_event(|app, event| {

--- a/src-tauri/tests/tray.rs
+++ b/src-tauri/tests/tray.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+#[test]
+fn tray_icon_png_exists_and_non_empty() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let icon_path = format!("{}/icons/32x32.png", manifest_dir);
+    let data = fs::read(icon_path).expect("read tray icon 32x32.png");
+    assert!(!data.is_empty(), "tray icon should not be empty");
+}
+
+#[test]
+fn cargo_tauri_features_include_image_png_and_tray_icon() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_toml_path = format!("{}/Cargo.toml", manifest_dir);
+    let data = fs::read_to_string(cargo_toml_path).expect("read Cargo.toml");
+    let v: toml::Value = toml::from_str(&data).expect("parse Cargo.toml");
+
+    let features = v["dependencies"]["tauri"]["features"]
+        .as_array()
+        .expect("tauri features should be an array")
+        .iter()
+        .filter_map(|x| x.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(features.contains(&"tray-icon"), "missing tray-icon feature");
+    assert!(features.contains(&"image-png"), "missing image-png feature");
+}
+

--- a/src-tauri/tests/tray.rs
+++ b/src-tauri/tests/tray.rs
@@ -25,4 +25,3 @@ fn cargo_tauri_features_include_image_png_and_tray_icon() {
     assert!(features.contains(&"tray-icon"), "missing tray-icon feature");
     assert!(features.contains(&"image-png"), "missing image-png feature");
 }
-


### PR DESCRIPTION
…ng tauri image-png feature

- Set tray icon from icons/32x32.png and icon_as_template(true)
- Enable tauri  feature in src-tauri/Cargo.toml
- Add tests to verify icon asset and features

Refs: menu bar icon visibility; Quit remains available via menu