### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,6 @@
 name: "Check spelling"
+permissions:
+  contents: read
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/6](https://github.com/9renpoto/time-wise/security/code-scanning/6)

To fix the problem, an explicit `permissions` field should be added specifying the minimal permissions required for the job. Since the spellchecking action just needs to fetch code and does not need to write to the repository or interact with pull requests/issues, we can safely use `contents: read` as the sole explicit permission. This can be placed at the top of the workflow (root-level) to apply to all jobs, or inside the `spellcheck` job directly; in this case, following the provided file structure, the root-level addition is simplest and clearest. Only one line needs to be added after the `name:` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
