### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/5](https://github.com/9renpoto/time-wise/security/code-scanning/5)

To fix the problem, an explicit `permissions` block should be added to the workflow for the jobs that require GITHUB_TOKEN access. The stale workflow needs the ability to modify issues and pull requests, so it requires `issues: write` and `pull-requests: write`. It might also need `contents: read` to access repository metadata, but does not need further write permissions. The `permissions` block can be set either at the top of the workflow (applies to all jobs), or under the specific job (`stale`). To minimally fix the detected error, a `permissions` block should be added to the `stale` job in `.github/workflows/stale.yml`, just above `runs-on`. No method definitions or imports are required—this is entirely a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
