### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,4 +1,7 @@
 name: Bump version
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/4](https://github.com/9renpoto/time-wise/security/code-scanning/4)

To fix this issue, you should add a `permissions` key to the workflow, configured at the root level or for the job itself. This limits the `GITHUB_TOKEN` permissions to only those required by the workflow. In this case, the workflow checks out code, reads releases, writes to repository contents (updating CHANGELOG.md), and creates pull requests. Therefore, at minimum, you should grant `contents: write` (to update the repo and push changes), and `pull-requests: write` (to open a PR). Place this block either directly under the workflow `name` or inside the `bump` job block (recommended at root to ensure coverage).  
You do **not** need to add any new imports or definitions—this is a workflow-level change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
