### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,6 @@
 name: actionlint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/3](https://github.com/9renpoto/time-wise/security/code-scanning/3)

To fix this problem, you should add an explicit `permissions` block limiting the GITHUB_TOKEN's access. The minimal, recommended baseline is `contents: read`, which allows read-only access to the repository contents. This can be added at either the workflow root or the job level; the latter makes sense if you want to restrict it per-job, but here there is only one job, so adding it at the root is clearer and more maintainable.

**Steps to fix:**
- Add a `permissions:` key at the top of `.github/workflows/actionlint.yml`, after the workflow `name:` and before `on:`.
- Set `contents: read` as the value.
- No additional imports, dependencies, or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
