### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/2](https://github.com/9renpoto/time-wise/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow, ideally at the top level (before `jobs:`). This block should specify the minimum permissions required for the workflow's jobs. Based on the tasks in the provided job—checking out code, running tests, and pushing coverage data to Codecov through its own token—no write access is needed to the repository contents, issues, or pull requests, so the minimal permission should be `contents: read`. Add the following snippet under the workflow `name:` and before `on:`, or immediately below `on:` if preferred for readability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
