### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-schedule.yml
+++ b/.github/workflows/bump-schedule.yml
@@ -1,4 +1,6 @@
 name: Bump version (cron)
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/9renpoto/time-wise/security/code-scanning/1](https://github.com/9renpoto/time-wise/security/code-scanning/1)

To fix the issue, explicitly add a `permissions` block to the workflow at the root level (right below `name` or atop `jobs`), or inside the specific job (`scheduled_bump`). Since this file delegates to another workflow via `uses`, safest practice is to specify least privilege at the root level for the entire workflow. Given that most "bump" workflows need `contents: write` (to push changes) and occasionally might need `pull-requests: write` (to open PRs), you should use restrictive permissions: `contents: write` and only other `write` scopes if strictly needed. Add this directly below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
