### PR TITLE
Update Dependabot configuration with cooldown and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,19 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*"
+          - "actions/checkout"
+          - "actions/github-script"
+          - "actions/download-artifact"
+          - "actions/setup-node"
+          - "actions/stale"
+          - "peter-evans/create-pull-request"
+          - "dtolnay/rust-toolchain"
+          - "codecov/codecov-action"
+          - "tauri-apps/tauri-action"
+          - "crate-ci/typos"
+          - "EndBug/export-label-config"
+          - "EndBug/label-sync"
+          - "reviewdog/action-actionlint"
     cooldown:
       default-days: 7
 
@@ -20,8 +32,22 @@ updates:
     labels:
       - "Type: Maintenance"
     groups:
-      cargo:
+      tauri-dependencies:
         patterns:
-          - "*"
+          - "tauri"
+          - "tauri-build"
+          - "tauri-plugin-autostart"
+          - "tauri-plugin-opener"
+      serde-dependencies:
+        patterns:
+          - "serde"
+          - "serde_json"
+          - "serde-wasm-bindgen"
+      wasm-dependencies:
+        patterns:
+          - "wasm-bindgen"
+          - "wasm-bindgen-futures"
+          - "js-sys"
+          - "web-sys"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,10 @@ updates:
     groups:
       actions:
         patterns:
-          - "actions/checkout"
-          - "actions/github-script"
-          - "actions/download-artifact"
-          - "actions/setup-node"
-          - "actions/stale"
+          - "actions/*"
       endbug:
         patterns:
-          - "EndBug/export-label-config"
-          - "EndBug/label-sync"
+          - "EndBug/*"
     cooldown:
       default-days: 7
 
@@ -30,19 +25,13 @@ updates:
     groups:
       tauri:
         patterns:
-          - "tauri"
-          - "tauri-build"
-          - "tauri-plugin-autostart"
-          - "tauri-plugin-opener"
+          - "tauri*"
       serde:
         patterns:
-          - "serde"
-          - "serde_json"
-          - "serde-wasm-bindgen"
+          - "serde*"
       rustwasm:
         patterns:
-          - "wasm-bindgen"
-          - "wasm-bindgen-futures"
+          - "wasm-bindgen*"
           - "js-sys"
           - "web-sys"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,21 +7,17 @@ updates:
     labels:
       - "Type: Maintenance"
     groups:
-      github-actions:
+      actions:
         patterns:
           - "actions/checkout"
           - "actions/github-script"
           - "actions/download-artifact"
           - "actions/setup-node"
           - "actions/stale"
-          - "peter-evans/create-pull-request"
-          - "dtolnay/rust-toolchain"
-          - "codecov/codecov-action"
-          - "tauri-apps/tauri-action"
-          - "crate-ci/typos"
+      endbug:
+        patterns:
           - "EndBug/export-label-config"
           - "EndBug/label-sync"
-          - "reviewdog/action-actionlint"
     cooldown:
       default-days: 7
 
@@ -32,18 +28,18 @@ updates:
     labels:
       - "Type: Maintenance"
     groups:
-      tauri-dependencies:
+      tauri:
         patterns:
           - "tauri"
           - "tauri-build"
           - "tauri-plugin-autostart"
           - "tauri-plugin-opener"
-      serde-dependencies:
+      serde:
         patterns:
           - "serde"
           - "serde_json"
           - "serde-wasm-bindgen"
-      wasm-dependencies:
+      rustwasm:
         patterns:
           - "wasm-bindgen"
           - "wasm-bindgen-futures"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,22 @@ updates:
       interval: "weekly"
     labels:
       - "Type: Maintenance"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "Type: Maintenance"
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Type: Maintenance"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Updated `.github/dependabot.yml` to include a 7-day cooldown period and grouped updates for `github-actions` and `cargo`. The `npm` ecosystem was removed as it appears to be unused in this project.

---
*PR created automatically by Jules for task [16674916884500128464](https://jules.google.com/task/16674916884500128464) started by @9renpoto*