### PR TITLE
fix: resolve clippy unnecessary_sort_by in CI

### DIFF
--- a/src-tauri/src/app_usage.rs
+++ b/src-tauri/src/app_usage.rs
@@ -64,7 +64,7 @@ impl AppUsageRecorder {
             .map(|entry| entry.to_record(instant_now, system_now))
             .filter(|record| record.total_active_ms > 0 || record.active)
             .collect();
-        records.sort_by(|a, b| b.total_active_ms.cmp(&a.total_active_ms));
+        records.sort_by_key(|record| std::cmp::Reverse(record.total_active_ms));
         records
     }
 

--- a/src/infrastructure/tauri_adapter.rs
+++ b/src/infrastructure/tauri_adapter.rs
@@ -109,7 +109,7 @@ pub async fn set_autostart_enabled(enabled: bool) -> AutostartStatus {
 pub async fn load_startup_records() -> Vec<StartupRecord> {
     match invoke_command::<Vec<StartupRecord>>("fetch_startup_records").await {
         Ok(mut records) => {
-            records.sort_by(|a, b| b.recorded_at_ms.cmp(&a.recorded_at_ms));
+            records.sort_by_key(|record| std::cmp::Reverse(record.recorded_at_ms));
             records
         }
         Err(err) => {


### PR DESCRIPTION
## Summary
- replace descending `sort_by` calls flagged by Clippy
- use `sort_by_key` + `std::cmp::Reverse` in both failing locations

## Why
CI for #85 fails on `clippy::unnecessary_sort_by` with `-D warnings`. This PR fixes the same lint failure on `main` so the dependency PR can be recreated cleanly.