### PR TITLE
Upgrade Rust toolchain to 1.95.0 to resolve rusqlite 0.40 compile failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.95.0
+      uses: dtolnay/rust-toolchain@1.95.0
       with:
-        toolchain: 1.95.0
         components: clippy, rustfmt, llvm-tools
     - name: Install grcov
       run: cargo install grcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.89.0
+      uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.95.0
       with:
+        toolchain: 1.95.0
         components: clippy, rustfmt, llvm-tools
     - name: Install grcov
       run: cargo install grcov

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -29,8 +29,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.89.0
+        uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.95.0
         with:
+          toolchain: 1.95.0
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
       - name: Install trunk

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -29,9 +29,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e # 1.95.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
-          toolchain: 1.95.0
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
       - name: Install trunk

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
-rusqlite = { version = "0.38", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 sysinfo = { version = "0.38" }
 tokio = { version = "1", features = ["time"] }
 


### PR DESCRIPTION
Resolves the test/clippy compilation failure under pull request #87 when upgrading rusqlite requirement from 0.38 to 0.40. By upgrading the Rust toolchain to 1.95.0 or later, we support the new `cfg_select!` macro utilized in the updated `libsqlite3-sys` dependency.

---
*PR created automatically by Jules for task [11454281396175226971](https://jules.google.com/task/11454281396175226971) started by @9renpoto*