### PR TITLE
docs: define bilingual screen time requirements

### DIFF
--- a/docs/adr/0001-track-focused-application-time.md
+++ b/docs/adr/0001-track-focused-application-time.md
@@ -1,0 +1,140 @@
+# ADR 0001: フォーカスアプリの利用時間を計測する / Track focused application usage
+
+- 状態 / Status: 検討中 / Proposed
+- 日付 / Date: 2026-07-27
+
+## コンテキスト / Context
+
+### 日本語
+
+Time Wise は、既存のスクリーンタイムアプリを参考に、ユーザーがアプリを利用した時間を記録する。
+
+現在の実装は、一定間隔で起動中のプロセスを取得し、プロセスが存在していた時間を利用時間として扱っている。この方法では、バックグラウンドで動作しているアプリも利用中として記録されるため、ユーザーが実際に操作していた時間を表せない。
+
+OS ごとに取得できる情報や必要な権限が異なるため、具体的な取得方法はプラットフォームごとに選択する必要がある。
+
+### English
+
+Time Wise records how long users spend in applications, taking existing screen-time applications as product references.
+
+The current implementation periodically enumerates running processes and treats process lifetime as usage time. This records background applications as active usage and therefore does not represent the applications the user was actually using.
+
+Available information and required permissions vary by operating system, so each platform requires its own collection implementation.
+
+## 決定 / Decision
+
+### 日本語
+
+- 基本的な計測対象を、前面でフォーカスされているアプリとする。単にプロセスが起動している時間は利用時間として扱わない。
+- 画面ロック中およびスリープ中の時間を利用時間から除外する。キーボードやマウスの無操作時間だけを根拠としたアイドル除外は行わない。
+- v1 の正式対応 OS と配布対象は Windows とする。Linux と macOS は、将来アダプターを追加できる境界だけを維持する。
+- 利用時間はアプリ単位で集計する。ブラウザも Chrome、Edge、Firefox などのアプリ単位で扱い、Web サイト、ドメイン、タブ単位には分解しない。
+- ウィンドウタイトルは収集および保存しない。アプリの識別と表示に必要な最小限の情報だけを扱う。
+- 製品体験は macOS のスクリーンタイムを参考にする。ただし、Windows 向けの独立した実装とし、本 ADR の計測範囲とプライバシー方針を優先する。
+- v1 は利用時間の計測と可視化に限定する。今日の合計、アプリ別ランキング、時間帯別グラフ、日別・週別の切り替え、過去データをダッシュボードに表示する。
+- 利用制限、通知、カテゴリ分類は v1 に含めない。
+- 利用履歴は端末内だけに保存し、自動削除せず無期限に保持する。サーバー同期を将来導入する場合は、サーバー側の保持期間、同意、削除、セキュリティを別途設計する。
+- 設定画面から全利用履歴を削除できるようにし、実行前に確認を求める。期間指定、アプリ単位の削除、削除後の復元は提供しない。
+- 計測時刻は UTC で保存し、計測時の Windows ローカルタイムゾーンも保存する。日別履歴は計測時点のローカル日付に固定し、週は月曜日から開始する。
+- Windows のフォーカス変更イベントでアプリ切り替えを即時記録し、30 秒ごとに現在のセッションをチェックポイント保存する。内部では秒以下の精度を保持し、画面では分単位で表示する。
+- Windows ログイン時の自動起動は、初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ設定する。後から設定画面で変更できる。
+- Time Wise の起動中はトレイに常駐して常時計測する。一時停止・再開機能は提供せず、アプリを終了すると計測を停止する。
+- Time Wise 自身は常に計測対象から除外する。Explorer やタスクマネージャーなど、通常操作できる Windows アプリは原則として計測する。
+- ユーザー向けの任意アプリ除外および URL・Web サイト単位の除外は提供しない。原理検証や自動テスト用の切り替えは、開発・テスト専用として実装してよい。
+- 同じ製品の複数ウィンドウ、プロセス、ブラウザプロファイルは、一つのアプリとして合算する。画面には製品名と代表アイコンを表示する。
+- 履歴と設定は、現在ログインしている Windows ユーザーのローカル領域へ保存し、別のユーザーアカウントとは共有しない。
+- アプリ識別子を取得できない時間は「未分類」として総利用時間とアプリ別表示に残す。後から権限が得られても、過去時間を推測で再分類しない。
+- 識別子を取得済みで、表示名やアイコンだけが不足している場合は、後からメタデータを補完して過去履歴の表示へ反映してよい。
+- Windows 11 実機でフォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を受け入れ確認する。
+- GitHub Actions では、Ubuntu で OS 非依存の中核を検証し、Windows でワークスペース全体をビルドおよびテストする。リリース成果物は Windows 向けだけを生成する。
+
+### English
+
+- Measure the application currently focused in the foreground. Do not treat the lifetime of a running process as usage time.
+- Exclude time while the screen is locked or the computer is asleep. Do not exclude time solely because there has been no keyboard or mouse input.
+- Support and distribute v1 for Windows. Preserve boundaries that allow Linux and macOS adapters to be added later.
+- Aggregate usage by application. Treat Chrome, Edge, Firefox, and other browsers as applications; do not break usage down by website, domain, or tab.
+- Do not collect or store window titles. Handle only the minimum information required to identify and display an application.
+- Use macOS Screen Time as a product-experience reference, while building an independent Windows implementation governed by the scope and privacy rules in this ADR.
+- Limit v1 to measurement and visualization. Show today's total, application rankings, an hourly chart, daily and weekly views, and historical data.
+- Exclude usage limits, notifications, and category classification from v1.
+- Store history only on the device, retain it indefinitely, and do not synchronize it with a server. Define separate retention, consent, deletion, and security rules before adding server synchronization.
+- Allow users to delete all usage history from Settings after confirmation. Do not provide deletion by date range or application, or recovery after deletion.
+- Store timestamps in UTC together with the Windows local time zone at measurement time. Assign history permanently to the local date observed at measurement time, and start weeks on Monday.
+- Record application switches immediately from Windows foreground-change events. Checkpoint the current session every 30 seconds. Retain sub-second internal precision and display usage in minutes.
+- Explain autostart during onboarding and enable it only after explicit user consent. Allow the setting to be changed later.
+- Measure continuously while Time Wise is running in the system tray. Do not provide pause and resume states. Stop measurement when the application exits.
+- Always exclude Time Wise itself. Measure ordinarily interactive Windows applications such as Explorer and Task Manager by default.
+- Do not provide user-facing exclusion rules for applications, URLs, or websites. Development-only switches may be used for proof-of-concept work and automated tests.
+- Combine multiple windows, processes, and browser profiles belonging to the same product into one application. Display one product name and representative icon.
+- Store history and settings in the current Windows user's local data area and do not share them with other Windows accounts.
+- Keep time for which no application identifier could be obtained as Unclassified in both totals and application views. Do not infer a historical classification after permissions change.
+- If an identifier was captured but its display name or icon was unavailable, metadata may be added later and reflected in historical views.
+- Perform acceptance testing for focus changes, screen lock, sleep, autostart, and tray behavior on physical Windows 11 hardware.
+- Use GitHub Actions to test the OS-independent core on Ubuntu and the complete workspace on Windows. Produce release artifacts for Windows only.
+
+## 理由 / Rationale
+
+### 日本語
+
+- 一般的なスクリーンタイムの意味に近い計測結果になる。
+- バックグラウンド常駐アプリによる過大計上を避けられる。
+- アプリ別時間をユーザーが直感的に理解しやすい。
+- 動画視聴、文書の閲覧、オンライン会議など、入力操作を伴わない利用を計測できる。
+
+### English
+
+- The result more closely matches the common meaning of screen time.
+- Background applications do not inflate recorded usage.
+- Application-level totals are easier for users to understand.
+- Passive but intentional activity, including watching video, reading, and attending online meetings, remains measurable.
+
+## 影響 / Consequences
+
+### 日本語
+
+- 現在のプロセス一覧ベースの計測処理を置き換えるか、役割を限定する必要がある。
+- Windows 固有の取得処理をインフラストラクチャ層へ閉じ込め、ドメイン層とアプリケーション層から分離する必要がある。
+- デスクトップアプリとパッケージアプリを、安定した製品単位へ解決する識別処理が必要になる。
+- ブラウザ内の Web サイト別時間、同じ製品のプロファイル別・ウィンドウ別時間は確認できない。
+- 文書名、メール件名、閲覧ページ名などがウィンドウタイトルを通じて保存されることを防げる一方、タイトルに依存した識別はできない。
+- ロックせずに離席した時間は利用時間に含まれる。将来アイドル時間を推定する場合も、メディア視聴などを誤って除外しない設計が必要になる。
+- ローカルデータ量と集計性能を監視する必要がある。同期を追加するまでは複数端末を横断した集計や復元はできない。
+- 全履歴削除は取り消せないため、対象と結果を確認画面で明確に伝える必要がある。
+- タイムゾーン変更後も過去の日別集計は安定するが、UTC 時刻に加えて計測時のタイムゾーンまたは確定したローカル日付を永続化する必要がある。
+- イベント購読の停止を検知する必要がある。異常終了時に失われる直近の計測時間は、原則として最大約 30 秒になる。
+- Windows のユーザー切り替え時は、各ユーザーのプロセスと保存領域を独立して扱う必要がある。
+- 未分類時間により総利用時間の欠落を防げるが、識別できなかった過去時間は権限取得後も未分類として残る。
+- OS イベントを伴う動作は CI だけでは保証できないため、Windows 11 実機での受け入れ確認が必要になる。
+- OS 非依存ロジックを Windows 固有コードから分離し、Ubuntu CI でも検証可能にする必要がある。
+
+### English
+
+- The current process-enumeration recorder must be replaced or given a narrower role.
+- Windows-specific collection must remain in the infrastructure layer, separate from domain and application logic.
+- Desktop and packaged Windows applications require resolution to stable product-level identities.
+- The product will not report usage by website, browser profile, or individual window.
+- Avoiding window titles prevents storage of document names, email subjects, and page titles, but also prevents title-based identification.
+- Time spent away from an unlocked computer remains usage time. Any future idle-time estimation must avoid excluding passive media consumption.
+- Local data volume and query performance require monitoring. Cross-device aggregation and recovery are unavailable until synchronization is added.
+- Deleting all history is irreversible, so the confirmation must clearly communicate its scope and result.
+- Historical daily totals remain stable after time-zone changes, but the system must persist either the measurement-time zone or the finalized local date in addition to UTC timestamps.
+- The recorder must detect stopped event subscriptions. A crash should lose no more than approximately 30 seconds of recent usage under normal conditions.
+- Each signed-in Windows user requires an independent process context and data location.
+- Unclassified time prevents gaps in the total, but historically unidentified time remains unclassified after permissions change.
+- CI alone cannot validate operating-system events, so acceptance testing on physical Windows 11 hardware is required.
+- OS-independent logic must remain separate from Windows-specific code so it can also be tested in Ubuntu CI.
+
+## 未決事項 / Open questions
+
+### 日本語
+
+- 日付変更や瞬間的なフォーカス喪失を利用セッション境界として扱う詳細規則。
+- OS 権限がない場合の表示とフォールバック。
+- OS 権限やイベント購読が失敗した場合のユーザー向けエラー表示。
+
+### English
+
+- Detailed session-boundary rules for date changes and momentary focus loss.
+- Display and fallback behavior when OS permissions are unavailable.
+- User-facing errors for permission failures and failed event subscriptions.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,137 @@
+# Time Wise 用語集 / Glossary
+
+Time Wise の要件、実装、画面表示で使用する用語を定義する。未決の定義は、要件整理の進行に合わせて更新する。
+
+This reference defines terminology used in Time Wise requirements, implementation, and user interfaces. Definitions that remain open will be updated as requirements are refined.
+
+## フォーカスアプリ / Focused application
+
+ユーザーのデスクトップで前面にあり、現在入力を受け取る対象となっているアプリ。
+
+The foreground application that is currently eligible to receive user input.
+
+## 利用時間 / Usage time
+
+アプリがフォーカスアプリとして観測された時間を基礎に算出する時間。バックグラウンドで起動しているだけの時間、画面ロック中、スリープ中は含めない。入力操作がなくても、フォーカスアプリが表示され、画面が利用可能な時間は含める。
+
+Time calculated from periods in which an application was observed as focused. It excludes time when a process was merely running in the background, the screen was locked, or the computer was asleep. It includes time when the focused application was visible and the screen was available, even without input activity.
+
+## 計測サンプル / Measurement sample
+
+ある時点で観測したフォーカスアプリの識別情報と観測時刻。フォーカス変更イベントで取得し、30 秒ごとのチェックポイントでも現在の状態を確認する。
+
+The focused application's identity and observation time at a particular moment. Samples come from foreground-change events, with the current state also checked at 30-second checkpoints.
+
+## 利用セッション / Usage session
+
+同じアプリが継続してフォーカスされていた期間。画面ロックとスリープはセッションを中断する。日付変更や瞬間的なフォーカス喪失を境界とする詳細規則は未決。
+
+A continuous period during which the same application was focused. Screen lock and sleep interrupt a session. Detailed boundary rules for date changes and momentary focus loss remain open.
+
+## アイドル状態 / Idle state
+
+アプリがフォーカスされていても、ユーザー入力が一定時間観測されていない状態。動画視聴、文書の閲覧、オンライン会議など、入力操作を伴わない利用も含み得る。v1 では利用時間から除外しない。
+
+A state in which an application remains focused but no user input has been observed for a period. This can include intentional use without input, such as watching video, reading, or attending an online meeting. v1 does not exclude this state from usage time.
+
+## 画面ロック / Screen lock
+
+OS のユーザーセッションがロックされ、アプリを操作できない状態。この期間は利用時間から除外する。
+
+A state in which the operating-system user session is locked and applications cannot be used. This period is excluded from usage time.
+
+## スリープ / Sleep
+
+コンピューターまたは対象セッションの動作が一時停止している状態。この期間は利用時間から除外する。
+
+A state in which the computer or relevant session is suspended. This period is excluded from usage time.
+
+## 正式対応 OS / Supported operating system
+
+リリース時に計測精度と主要機能を検証し、動作を保証する OS。v1 では Windows を正式対応 OS および配布対象とする。Linux と macOS は、将来アダプターを追加できるアーキテクチャ境界だけを維持する。
+
+An operating system on which measurement accuracy and primary features are validated for release. Windows is the supported and distributed platform for v1. Linux and macOS retain only architectural boundaries for future adapters.
+
+## アプリ / Application
+
+利用時間を集計する単位。Windows 上で安定して取得できる識別情報を基に同一性を判定する。ブラウザはブラウザ自体を一つのアプリとして扱い、Web サイト、ドメイン、タブには分けない。同じ製品の複数ウィンドウ、プロセス、ブラウザプロファイルも一つに合算する。
+
+The unit used to aggregate usage time, identified from stable information available on Windows. A browser is treated as one application rather than being divided by website, domain, or tab. Multiple windows, processes, and browser profiles belonging to the same product are combined.
+
+## アプリ識別情報 / Application identity
+
+同じアプリの計測サンプルをまとめ、アプリ名やアイコンを表示するための最小限の情報。実行ファイルの識別子、表示名、アイコン取得用の参照などを想定する。ウィンドウタイトル、文書名、メール件名、閲覧 URL、Web サイト名は含めない。表示情報だけが不足している場合は後から補完できる。
+
+The minimum information needed to group samples from the same application and display its name and icon. It may include an executable identifier, display name, and an icon reference. It excludes window titles, document names, email subjects, browsing URLs, and website names. Missing display metadata may be added later.
+
+## 未分類 / Unclassified
+
+フォーカスアプリの識別子を取得できず、特定のアプリへ割り当てられない利用時間。総利用時間へ含め、アプリ別表示では独立した項目として扱う。後から権限が得られても過去分を推測で再分類せず、新しいセッションから通常の分類を始める。
+
+Usage time for which no focused-application identifier could be obtained. It is included in total usage and shown as a separate application-level item. Historical time is not reclassified by inference after permissions change; normal classification begins with new sessions.
+
+## 受け入れ確認 / Acceptance testing
+
+Windows 11 実機でフォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を確認し、v1 の要件を満たすか判断する手動検証。自動ビルドと自動テストは GitHub Actions で実行する。
+
+Manual validation on physical Windows 11 hardware to determine whether focus changes, screen lock, sleep, autostart, and tray behavior satisfy v1 requirements. Automated builds and tests run in GitHub Actions.
+
+## ポータブル中核 / Portable core
+
+特定 OS の API に依存しないドメインモデル、利用セッション処理、SQLite 永続化、日別・週別集計。Windows CI に加え、Ubuntu CI でも自動テストする。
+
+Domain models, usage-session processing, SQLite persistence, and daily and weekly aggregation that do not depend on a specific operating-system API. The portable core is tested in both Windows and Ubuntu CI.
+
+## 計測と可視化 / Measurement and visualization
+
+v1 の中核機能。フォーカスアプリの利用時間を記録し、今日の合計、アプリ別ランキング、時間帯別グラフ、日別・週別表示、過去データとして確認できるようにする。利用制限、通知、カテゴリ分類は含まない。
+
+The core v1 capability. It records focused-application usage and presents today's total, application rankings, an hourly chart, daily and weekly views, and historical data. It excludes usage limits, notifications, and category classification.
+
+## ローカル履歴 / Local history
+
+Windows ユーザーアカウントごとの端末内領域に保存された利用履歴。v1 ではサーバーへ送信せず、自動削除も行わず、無期限に保持する。将来サーバー同期を導入する場合は、別の保持規則を定める。
+
+Usage history stored on the device for an individual Windows user account. v1 does not send it to a server, delete it automatically, or share it with other accounts, and retains it indefinitely. Server synchronization will require separate retention rules.
+
+## 全履歴削除 / Delete all history
+
+端末内のすべての利用履歴を削除する操作。v1 では実行前に確認を求め、削除後の復元、期間指定、アプリ単位の削除は提供しない。
+
+An operation that deletes all usage history from the device. v1 requires confirmation and does not provide recovery, date-range deletion, or application-specific deletion.
+
+## 計測日 / Measurement date
+
+利用時間を日別に集計する日付。計測時点の Windows ローカル日付を使用し、後から端末のタイムゾーンが変わっても過去の計測日は変更しない。
+
+The date used for daily usage aggregation. It is the Windows local date at measurement time and does not change retrospectively when the device's time zone changes.
+
+## 週 / Week
+
+月曜日から日曜日までの計測日のまとまり。週別表示の集計単位として使用する。
+
+A group of measurement dates from Monday through Sunday, used as the aggregation unit for weekly views.
+
+## チェックポイント / Checkpoint
+
+進行中の利用セッションを定期的に永続化する処理。v1 では 30 秒ごとに保存し、異常終了時の未保存時間を制限する。
+
+Periodic persistence of an in-progress usage session. v1 saves a checkpoint every 30 seconds to limit uncommitted time after an abnormal exit.
+
+## 自動起動 / Autostart
+
+Windows へのログイン時に Time Wise を起動し、トレイ常駐で計測を始める設定。初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ使用する。後から設定画面で変更できる。
+
+A setting that starts Time Wise at Windows sign-in and begins measurement in the system tray. It is explained during onboarding, enabled only with explicit user consent, and can be changed later in Settings.
+
+## 計測継続状態 / Continuous measurement
+
+Time Wise が起動し、フォーカスアプリの利用時間を記録している状態。v1 では一時停止状態を設けず、アプリが終了するまで計測を継続する。
+
+The state in which Time Wise is running and recording focused-application usage. v1 has no paused state and continues measurement until the application exits.
+
+## 常時除外アプリ / Always-excluded application
+
+フォーカスされても利用時間へ記録しないアプリ。v1 では Time Wise 自身だけを常時除外する。ユーザーが任意のアプリや URL を追加する除外設定は提供しない。検証用の切り替えは製品機能に含めない。
+
+An application whose focused time is never recorded. In v1, only Time Wise itself is always excluded. Users cannot add applications or URLs to an exclusion list, and validation switches are not product features.


### PR DESCRIPTION
## Summary

- document the Windows v1 focused-application usage model
- define privacy, persistence, lifecycle, aggregation, and release decisions
- provide matching Japanese and English requirements and terminology

## Why

The implementation work in #100 through #111 needs a shared definition of usage time and explicit product boundaries before Windows-specific development begins.

## Impact

This PR adds documentation only. It does not change application behavior.

## Validation

- `git diff --cached --check`
- pre-commit `typos`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`

## Related issues

- #100
