### PR TITLE
feat: model app identities and usage sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,12 +118,25 @@ jobs:
         if: steps.changes.outputs.scope != 'none'
         run: cargo install grcov
 
-      - name: Run workspace tests with coverage
+      - name: Run tests with coverage
         if: steps.changes.outputs.scope != 'none'
+        shell: bash
         env:
           RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p.profraw"
-        run: cargo test --workspace
+          SCOPE: ${{ steps.changes.outputs.scope }}
+        run: |
+          case "$SCOPE" in
+            ui)
+              cargo test -p time-wise-ui
+              ;;
+            tauri)
+              cargo test -p time-wise
+              ;;
+            workspace)
+              cargo test --workspace
+              ;;
+          esac
 
       - name: Generate coverage report
         if: steps.changes.outputs.scope != 'none'

--- a/src/domain/app_identity.rs
+++ b/src/domain/app_identity.rs
@@ -1,0 +1,92 @@
+#![allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AppIdentity(String);
+
+impl AppIdentity {
+    pub fn new(key: impl Into<String>) -> Result<Self, AppIdentityError> {
+        let key = key.into();
+        if key.trim().is_empty() {
+            return Err(AppIdentityError::EmptyStableKey);
+        }
+        Ok(Self(key))
+    }
+    #[must_use]
+    pub fn stable_key(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppIdentityError {
+    EmptyStableKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppDisplayMetadata {
+    pub display_name: String,
+    pub executable: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UsageSubject {
+    Identified(AppIdentity),
+    Unclassified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MeasurementDisposition {
+    Track(UsageSubject),
+    ExcludeTimeWise,
+}
+
+pub struct MeasurementPolicy {
+    own_identity: AppIdentity,
+}
+
+impl MeasurementPolicy {
+    #[must_use]
+    pub fn new(own_identity: AppIdentity) -> Self {
+        Self { own_identity }
+    }
+    #[must_use]
+    pub fn classify(&self, identity: Option<AppIdentity>) -> MeasurementDisposition {
+        match identity {
+            Some(value) if value == self.own_identity => MeasurementDisposition::ExcludeTimeWise,
+            Some(value) => MeasurementDisposition::Track(UsageSubject::Identified(value)),
+            None => MeasurementDisposition::Track(UsageSubject::Unclassified),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn id(key: &str) -> AppIdentity {
+        AppIdentity::new(key).unwrap()
+    }
+
+    #[test]
+    fn identity_is_separate_from_metadata() {
+        let identity = id("product:editor");
+        let metadata = AppDisplayMetadata {
+            display_name: "Editor".into(),
+            executable: Some("editor.exe".into()),
+        };
+        assert_eq!(identity.stable_key(), "product:editor");
+        assert_eq!(metadata.display_name, "Editor");
+    }
+
+    #[test]
+    fn unclassified_and_self_exclusion_are_explicit() {
+        let own = id("product:time-wise");
+        let policy = MeasurementPolicy::new(own.clone());
+        assert_eq!(
+            policy.classify(Some(own)),
+            MeasurementDisposition::ExcludeTimeWise
+        );
+        assert_eq!(
+            policy.classify(None),
+            MeasurementDisposition::Track(UsageSubject::Unclassified)
+        );
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,2 +1,4 @@
+pub mod app_identity;
 pub mod app_usage_record;
 pub mod startup_record;
+pub mod usage_session;

--- a/src/domain/usage_session.rs
+++ b/src/domain/usage_session.rs
@@ -1,0 +1,140 @@
+#![allow(dead_code)]
+use super::app_identity::UsageSubject;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterruptionReason {
+    SessionLocked,
+    SystemSuspended,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionEndReason {
+    FocusChanged,
+    Interrupted(InterruptionReason),
+    MeasurementStopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletedUsageSession {
+    pub subject: UsageSubject,
+    pub started_at_ms: u64,
+    pub ended_at_ms: u64,
+    pub end_reason: SessionEndReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageSession {
+    subject: UsageSubject,
+    started_at_ms: u64,
+}
+
+impl UsageSession {
+    #[must_use]
+    pub fn new(subject: UsageSubject, started_at_ms: u64) -> Self {
+        Self {
+            subject,
+            started_at_ms,
+        }
+    }
+    pub fn finish(
+        self,
+        ended_at_ms: u64,
+        end_reason: SessionEndReason,
+    ) -> Result<CompletedUsageSession, SessionTimeError> {
+        if ended_at_ms < self.started_at_ms {
+            return Err(SessionTimeError::EndBeforeStart);
+        }
+        Ok(CompletedUsageSession {
+            subject: self.subject,
+            started_at_ms: self.started_at_ms,
+            ended_at_ms,
+            end_reason,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTimeError {
+    EndBeforeStart,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MeasurementState {
+    Idle,
+    Measuring(UsageSession),
+    Interrupted {
+        since_ms: u64,
+        reason: InterruptionReason,
+    },
+}
+
+impl MeasurementState {
+    pub fn start(&mut self, subject: UsageSubject, at_ms: u64) {
+        *self = Self::Measuring(UsageSession::new(subject, at_ms));
+    }
+    pub fn interrupt(
+        &mut self,
+        at_ms: u64,
+        reason: InterruptionReason,
+    ) -> Result<Option<CompletedUsageSession>, SessionTimeError> {
+        let previous = std::mem::replace(
+            self,
+            Self::Interrupted {
+                since_ms: at_ms,
+                reason,
+            },
+        );
+        match previous {
+            Self::Measuring(session) => session
+                .finish(at_ms, SessionEndReason::Interrupted(reason))
+                .map(Some),
+            _ => Ok(None),
+        }
+    }
+    pub fn resume(&mut self) {
+        if matches!(self, Self::Interrupted { .. }) {
+            *self = Self::Idle;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::app_identity::AppIdentity;
+    fn subject() -> UsageSubject {
+        UsageSubject::Identified(AppIdentity::new("product:editor").unwrap())
+    }
+
+    #[test]
+    fn session_boundaries_are_deterministic() {
+        let done = UsageSession::new(subject(), 1_000)
+            .finish(4_000, SessionEndReason::FocusChanged)
+            .unwrap();
+        assert_eq!((done.started_at_ms, done.ended_at_ms), (1_000, 4_000));
+    }
+
+    #[test]
+    fn end_before_start_is_rejected() {
+        assert_eq!(
+            UsageSession::new(UsageSubject::Unclassified, 2_000)
+                .finish(1_999, SessionEndReason::MeasurementStopped),
+            Err(SessionTimeError::EndBeforeStart)
+        );
+    }
+
+    #[test]
+    fn lock_and_suspend_interrupt_sessions() {
+        for reason in [
+            InterruptionReason::SessionLocked,
+            InterruptionReason::SystemSuspended,
+        ] {
+            let mut state = MeasurementState::Idle;
+            state.start(subject(), 10);
+            let done = state.interrupt(20, reason).unwrap().unwrap();
+            assert_eq!(done.end_reason, SessionEndReason::Interrupted(reason));
+            state.resume();
+            assert_eq!(state, MeasurementState::Idle);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- define stable, OS-independent application identities separately from display metadata
- represent identified and unclassified usage subjects
- define Time Wise self-exclusion as an explicit measurement policy
- model usage-session completion, lock/suspend interruption, and resume transitions
- add deterministic unit tests for identity classification and session boundaries

## Why

Issue #102 establishes the domain model consumed by later Windows identity resolution, persistence, and event-driven recording work. Keeping process paths and display metadata outside the stable identity lets multiple windows and processes resolve to one product without coupling the model to Windows APIs.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

Refs #102
