### PR TITLE
feat: persist app usage history in SQLite

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod app_usage;
 #[cfg(any(debug_assertions, test))]
 mod platform;
 mod startup_metrics;
+pub mod usage_history;
 
 use std::env;
 use std::path::Path;
@@ -17,6 +18,7 @@ use tauri::{
     tray::TrayIconBuilder,
     Manager, RunEvent, State, WebviewUrl, WebviewWindow, Window,
 };
+use usage_history::UsageHistoryStore;
 
 #[cfg(not(target_os = "macos"))]
 use tauri::{PhysicalPosition, Position};
@@ -213,6 +215,20 @@ pub fn run() {
                 });
             let metrics = StartupMetrics::with_storage_path(storage_path);
             app.manage(metrics);
+
+            let usage_history_path = app
+                .path()
+                .resolve("usage_history.sqlite", BaseDirectory::AppLocalData)
+                .unwrap_or_else(|err| {
+                    eprintln!("failed to resolve usage history path: {err}");
+                    env::temp_dir().join("time-wise-usage-history.sqlite")
+                });
+            match UsageHistoryStore::with_storage_path(usage_history_path) {
+                Ok(store) => {
+                    app.manage(store);
+                }
+                Err(err) => eprintln!("failed to initialize usage history database: {err}"),
+            }
 
             tauri::WebviewWindowBuilder::new(
                 app,

--- a/src-tauri/src/usage_history.rs
+++ b/src-tauri/src/usage_history.rs
@@ -1,0 +1,362 @@
+//! SQLite persistence for application usage history.
+
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use std::{path::PathBuf, sync::Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppMetadata {
+    pub stable_key: String,
+    pub display_name: String,
+    pub executable: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageSubject<'a> {
+    Identified(&'a AppMetadata),
+    Unclassified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewUsageSession<'a> {
+    pub subject: UsageSubject<'a>,
+    pub started_at_utc_ms: u64,
+    pub ended_at_utc_ms: u64,
+    pub measured_timezone: &'a str,
+    pub measured_local_date: &'a str,
+    pub end_reason: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredUsageSession {
+    pub stable_key: Option<String>,
+    pub display_name: Option<String>,
+    pub executable: Option<String>,
+    pub started_at_utc_ms: u64,
+    pub ended_at_utc_ms: u64,
+    pub measured_timezone: String,
+    pub measured_local_date: String,
+    pub end_reason: String,
+}
+
+pub struct UsageHistoryStore {
+    connection: Mutex<Connection>,
+}
+
+impl UsageHistoryStore {
+    pub fn with_storage_path(path: PathBuf) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let connection = Connection::open(path).map_err(|error| error.to_string())?;
+        connection
+            .execute_batch("PRAGMA foreign_keys = ON;")
+            .map_err(|error| error.to_string())?;
+        Self::migrate(&connection).map_err(|error| error.to_string())?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    fn migrate(connection: &Connection) -> rusqlite::Result<()> {
+        connection.execute_batch(
+            "BEGIN;
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at_utc_ms INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS app_identities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                stable_key TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                executable TEXT,
+                updated_at_utc_ms INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS usage_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                app_identity_id INTEGER,
+                subject_kind TEXT NOT NULL CHECK (subject_kind IN ('identified', 'unclassified')),
+                started_at_utc_ms INTEGER NOT NULL,
+                ended_at_utc_ms INTEGER NOT NULL,
+                measured_timezone TEXT NOT NULL,
+                measured_local_date TEXT NOT NULL,
+                end_reason TEXT NOT NULL,
+                CHECK (ended_at_utc_ms >= started_at_utc_ms),
+                CHECK (
+                    (subject_kind = 'identified' AND app_identity_id IS NOT NULL)
+                    OR (subject_kind = 'unclassified' AND app_identity_id IS NULL)
+                ),
+                FOREIGN KEY (app_identity_id) REFERENCES app_identities(id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_usage_sessions_local_date
+                ON usage_sessions(measured_local_date, started_at_utc_ms);
+            CREATE INDEX IF NOT EXISTS idx_usage_sessions_app
+                ON usage_sessions(app_identity_id, started_at_utc_ms);
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at_utc_ms INTEGER NOT NULL
+            );
+            INSERT OR IGNORE INTO schema_migrations (version, applied_at_utc_ms)
+                VALUES (1, CAST(unixepoch('subsec') * 1000 AS INTEGER));
+            COMMIT;",
+        )
+    }
+
+    pub fn record_session(&self, session: &NewUsageSession<'_>) -> Result<i64, String> {
+        validate_session(session)?;
+        let mut connection = self
+            .connection
+            .lock()
+            .map_err(|_| "usage history mutex poisoned".to_string())?;
+        let transaction = connection
+            .transaction()
+            .map_err(|error| error.to_string())?;
+        let (kind, app_id) = match session.subject {
+            UsageSubject::Identified(metadata) => (
+                "identified",
+                Some(Self::upsert_app(
+                    &transaction,
+                    metadata,
+                    session.ended_at_utc_ms,
+                )?),
+            ),
+            UsageSubject::Unclassified => ("unclassified", None),
+        };
+        transaction
+            .execute(
+                "INSERT INTO usage_sessions (
+                app_identity_id, subject_kind, started_at_utc_ms, ended_at_utc_ms,
+                measured_timezone, measured_local_date, end_reason
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    app_id,
+                    kind,
+                    sql_timestamp(session.started_at_utc_ms)?,
+                    sql_timestamp(session.ended_at_utc_ms)?,
+                    session.measured_timezone,
+                    session.measured_local_date,
+                    session.end_reason
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        let id = transaction.last_insert_rowid();
+        transaction.commit().map_err(|error| error.to_string())?;
+        Ok(id)
+    }
+
+    fn upsert_app(
+        transaction: &Transaction<'_>,
+        metadata: &AppMetadata,
+        updated_at_utc_ms: u64,
+    ) -> Result<i64, String> {
+        non_empty("stable key", &metadata.stable_key)?;
+        non_empty("display name", &metadata.display_name)?;
+        transaction.execute(
+            "INSERT INTO app_identities (stable_key, display_name, executable, updated_at_utc_ms)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(stable_key) DO UPDATE SET
+                display_name = excluded.display_name,
+                executable = excluded.executable,
+                updated_at_utc_ms = excluded.updated_at_utc_ms",
+            params![metadata.stable_key, metadata.display_name, metadata.executable,
+                sql_timestamp(updated_at_utc_ms)?],
+        ).map_err(|error| error.to_string())?;
+        transaction
+            .query_row(
+                "SELECT id FROM app_identities WHERE stable_key = ?1",
+                params![metadata.stable_key],
+                |row| row.get(0),
+            )
+            .map_err(|error| error.to_string())
+    }
+
+    pub fn sessions_for_local_date(&self, date: &str) -> Result<Vec<StoredUsageSession>, String> {
+        let connection = self
+            .connection
+            .lock()
+            .map_err(|_| "usage history mutex poisoned".to_string())?;
+        let mut statement = connection
+            .prepare(
+                "SELECT apps.stable_key, apps.display_name, apps.executable,
+                sessions.started_at_utc_ms, sessions.ended_at_utc_ms,
+                sessions.measured_timezone, sessions.measured_local_date, sessions.end_reason
+             FROM usage_sessions AS sessions
+             LEFT JOIN app_identities AS apps ON apps.id = sessions.app_identity_id
+             WHERE sessions.measured_local_date = ?1
+             ORDER BY sessions.started_at_utc_ms, sessions.id",
+            )
+            .map_err(|error| error.to_string())?;
+        let rows = statement
+            .query_map(params![date], |row| {
+                Ok(StoredUsageSession {
+                    stable_key: row.get(0)?,
+                    display_name: row.get(1)?,
+                    executable: row.get(2)?,
+                    started_at_utc_ms: row.get::<_, i64>(3)?.max(0) as u64,
+                    ended_at_utc_ms: row.get::<_, i64>(4)?.max(0) as u64,
+                    measured_timezone: row.get(5)?,
+                    measured_local_date: row.get(6)?,
+                    end_reason: row.get(7)?,
+                })
+            })
+            .map_err(|error| error.to_string())?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| error.to_string())
+    }
+
+    pub fn set_setting(&self, key: &str, value: &str, at_utc_ms: u64) -> Result<(), String> {
+        non_empty("setting key", key)?;
+        let connection = self
+            .connection
+            .lock()
+            .map_err(|_| "usage history mutex poisoned".to_string())?;
+        connection
+            .execute(
+                "INSERT INTO settings (key, value, updated_at_utc_ms) VALUES (?1, ?2, ?3)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value,
+                updated_at_utc_ms = excluded.updated_at_utc_ms",
+                params![key, value, sql_timestamp(at_utc_ms)?],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    pub fn setting(&self, key: &str) -> Result<Option<String>, String> {
+        let connection = self
+            .connection
+            .lock()
+            .map_err(|_| "usage history mutex poisoned".to_string())?;
+        connection
+            .query_row(
+                "SELECT value FROM settings WHERE key = ?1",
+                params![key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| error.to_string())
+    }
+}
+
+fn validate_session(session: &NewUsageSession<'_>) -> Result<(), String> {
+    if session.ended_at_utc_ms < session.started_at_utc_ms {
+        return Err("usage session ends before it starts".to_string());
+    }
+    non_empty("measured timezone", session.measured_timezone)?;
+    non_empty("measured local date", session.measured_local_date)?;
+    non_empty("end reason", session.end_reason)
+}
+
+fn non_empty(label: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        Err(format!("{label} cannot be empty"))
+    } else {
+        Ok(())
+    }
+}
+
+fn sql_timestamp(value: u64) -> Result<i64, String> {
+    i64::try_from(value).map_err(|_| "timestamp exceeds SQLite INTEGER range".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, UsageHistoryStore) {
+        let directory = tempfile::tempdir().unwrap();
+        let store =
+            UsageHistoryStore::with_storage_path(directory.path().join("usage.sqlite")).unwrap();
+        (directory, store)
+    }
+
+    #[test]
+    fn persists_identified_and_unclassified_sessions() {
+        let (_directory, store) = store();
+        let app = AppMetadata {
+            stable_key: "product:editor".into(),
+            display_name: "Editor".into(),
+            executable: Some("editor.exe".into()),
+        };
+        store
+            .record_session(&NewUsageSession {
+                subject: UsageSubject::Identified(&app),
+                started_at_utc_ms: 1_000,
+                ended_at_utc_ms: 4_000,
+                measured_timezone: "Asia/Tokyo",
+                measured_local_date: "2026-07-31",
+                end_reason: "focus_changed",
+            })
+            .unwrap();
+        store
+            .record_session(&NewUsageSession {
+                subject: UsageSubject::Unclassified,
+                started_at_utc_ms: 4_000,
+                ended_at_utc_ms: 5_000,
+                measured_timezone: "Asia/Tokyo",
+                measured_local_date: "2026-07-31",
+                end_reason: "measurement_stopped",
+            })
+            .unwrap();
+        let sessions = store.sessions_for_local_date("2026-07-31").unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].stable_key.as_deref(), Some("product:editor"));
+        assert_eq!(sessions[0].display_name.as_deref(), Some("Editor"));
+        assert_eq!(sessions[1].stable_key, None);
+    }
+
+    #[test]
+    fn updates_metadata_for_a_stable_identity() {
+        let (_directory, store) = store();
+        let first = AppMetadata {
+            stable_key: "product:browser".into(),
+            display_name: "Old Name".into(),
+            executable: None,
+        };
+        let updated = AppMetadata {
+            stable_key: "product:browser".into(),
+            display_name: "Browser".into(),
+            executable: Some("browser.exe".into()),
+        };
+        for (app, start) in [(&first, 10), (&updated, 20)] {
+            store
+                .record_session(&NewUsageSession {
+                    subject: UsageSubject::Identified(app),
+                    started_at_utc_ms: start,
+                    ended_at_utc_ms: start + 10,
+                    measured_timezone: "UTC",
+                    measured_local_date: "2026-07-31",
+                    end_reason: "focus_changed",
+                })
+                .unwrap();
+        }
+        let sessions = store.sessions_for_local_date("2026-07-31").unwrap();
+        assert!(sessions
+            .iter()
+            .all(|session| session.display_name.as_deref() == Some("Browser")));
+        assert!(sessions
+            .iter()
+            .all(|session| session.executable.as_deref() == Some("browser.exe")));
+    }
+
+    #[test]
+    fn settings_are_upserted() {
+        let (_directory, store) = store();
+        store.set_setting("autostart", "false", 10).unwrap();
+        store.set_setting("autostart", "true", 20).unwrap();
+        assert_eq!(store.setting("autostart").unwrap().as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn rejects_invalid_session_boundaries() {
+        let (_directory, store) = store();
+        let result = store.record_session(&NewUsageSession {
+            subject: UsageSubject::Unclassified,
+            started_at_utc_ms: 2,
+            ended_at_utc_ms: 1,
+            measured_timezone: "UTC",
+            measured_local_date: "2026-07-31",
+            end_reason: "measurement_stopped",
+        });
+        assert_eq!(result.unwrap_err(), "usage session ends before it starts");
+    }
+}


### PR DESCRIPTION
## Summary

- add a versioned SQLite schema for app identities, usage sessions, and settings
- persist identified and unclassified sessions with UTC timestamps, measured timezone, and local date
- upsert display metadata independently from stable app identity
- initialize `usage_history.sqlite` in the Windows user-local app data directory
- add deterministic repository tests for persistence, metadata updates, settings, and invalid session bounds

## Impact

This establishes the local, indefinite history store needed by the Windows usage recorder and future daily/weekly queries. No server sync or automatic deletion is introduced.

## Validation

- `cargo fmt --all`
- `cargo clippy -p time-wise --bins --tests --examples -- -D rust_2018_idioms -D warnings`
- `cargo test --workspace` (34 passed)
- `git diff --check`

Closes #103