### PR TITLE
feat: implement resilient Windows usage recorder

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,17 +14,15 @@ edition = "2021"
 name = "time_wise_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
-[build-dependencies]
-tauri-build = { version = "2", features = [] }
-
 [dependencies]
-tauri-plugin-autostart = "2"
+chrono = "0.4.45"
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
-tauri-plugin-opener = "2"
-rusqlite = { version = "0.40", features = ["bundled"] }
 sysinfo = { version = "0.38" }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
+tauri-plugin-autostart = "2"
+tauri-plugin-opener = "2"
 tokio = { version = "1", features = ["time"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -39,6 +37,9 @@ windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
 [dev-dependencies]
-toml = "1.0"
 tempfile = "3"
+toml = "1.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,14 @@
 mod app_usage;
-#[cfg(any(debug_assertions, test))]
 mod platform;
 mod startup_metrics;
 pub mod usage_history;
+mod usage_recorder;
 
 use std::env;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
 
 use app_usage::{AppUsageRecord, AppUsageRecorder, APP_USAGE_POLL_INTERVAL};
 use startup_metrics::{fetch_startup_records, StartupMetrics};
@@ -19,6 +20,7 @@ use tauri::{
     Manager, RunEvent, State, WebviewUrl, WebviewWindow, Window,
 };
 use usage_history::UsageHistoryStore;
+use usage_recorder::{UsageRecorder, CHECKPOINT_INTERVAL_SECONDS};
 
 #[cfg(not(target_os = "macos"))]
 use tauri::{PhysicalPosition, Position};
@@ -177,18 +179,6 @@ pub fn run() {
         .setup(|app| {
             app.manage(UsageWindowState::default());
 
-            #[cfg(debug_assertions)]
-            {
-                if env::var("TIME_WISE_WINDOWS_EVENT_PROBE").as_deref() == Ok("1") {
-                    match platform::start_event_probe() {
-                        Ok(probe) => {
-                            app.manage(probe);
-                        }
-                        Err(err) => eprintln!("failed to start Windows event probe: {err}"),
-                    }
-                }
-            }
-
             let app_usage_recorder = AppUsageRecorder::default();
             if let Err(err) = app_usage_recorder.record_current_processes() {
                 eprintln!("failed to seed app usage data: {err}");
@@ -225,7 +215,35 @@ pub fn run() {
                 });
             match UsageHistoryStore::with_storage_path(usage_history_path) {
                 Ok(store) => {
+                    let store = Arc::new(store);
+                    let recorder = Arc::new(UsageRecorder::new(store.clone()));
                     app.manage(store);
+
+                    match platform::start_event_probe() {
+                        Ok((probe, event_receiver)) => {
+                            let event_recorder = recorder.clone();
+                            tauri::async_runtime::spawn_blocking(move || {
+                                while let Ok(event) = event_receiver.recv() {
+                                    event_recorder.handle_event(event);
+                                }
+                            });
+                            app.manage(probe);
+                        }
+                        Err(err) => {
+                            recorder.record_subscription_failure(err.clone());
+                            eprintln!("failed to start Windows event probe: {err}");
+                        }
+                    }
+
+                    let checkpoint_recorder = recorder.clone();
+                    tauri::async_runtime::spawn(async move {
+                        loop {
+                            tokio::time::sleep(Duration::from_secs(CHECKPOINT_INTERVAL_SECONDS))
+                                .await;
+                            checkpoint_recorder.checkpoint(SystemTime::now());
+                        }
+                    });
+                    app.manage(recorder);
                 }
                 Err(err) => eprintln!("failed to initialize usage history database: {err}"),
             }
@@ -379,13 +397,23 @@ pub fn run() {
 
     let launcher = resolve_launcher_name();
 
-    app.run(move |app_handle, event| {
-        if let RunEvent::Ready = event {
+    app.run(move |app_handle, event| match event {
+        RunEvent::Ready => {
             let metrics = app_handle.state::<StartupMetrics>();
             if let Err(err) = metrics.record_startup(startup_instant.elapsed(), launcher.clone()) {
                 eprintln!("failed to record startup time: {err}");
             }
         }
+        RunEvent::Exit => {
+            if let Some(recorder) = app_handle.try_state::<Arc<UsageRecorder>>() {
+                recorder.stop(SystemTime::now());
+                let diagnostics = recorder.diagnostics();
+                if diagnostics != Default::default() {
+                    eprintln!("usage recorder diagnostics at exit: {diagnostics:?}");
+                }
+            }
+        }
+        _ => {}
     });
 }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(target_os = "windows"), allow(dead_code))]
+
 use std::path::PathBuf;
 use std::time::SystemTime;
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,8 +1,4 @@
-#![cfg_attr(all(test, not(target_os = "windows")), allow(dead_code))]
-
-#[cfg(any(target_os = "windows", test))]
 use std::path::PathBuf;
-#[cfg(any(target_os = "windows", test))]
 use std::time::SystemTime;
 
 #[cfg(not(target_os = "windows"))]
@@ -15,7 +11,6 @@ pub use noop::start_event_probe;
 #[cfg(target_os = "windows")]
 pub use windows::start_event_probe;
 
-#[cfg(any(target_os = "windows", test))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DesktopEventKind {
     ForegroundChanged,
@@ -25,14 +20,12 @@ pub enum DesktopEventKind {
     Resumed,
 }
 
-#[cfg(any(target_os = "windows", test))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessIdentity {
     pub process_id: u32,
     pub executable: PathBuf,
 }
 
-#[cfg(any(target_os = "windows", test))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ObservationFailure {
     ForegroundWindowUnavailable,
@@ -41,7 +34,6 @@ pub enum ObservationFailure {
     ExecutablePathUnavailable(u32),
 }
 
-#[cfg(any(target_os = "windows", test))]
 #[derive(Clone, Debug)]
 pub struct DesktopEvent {
     pub observed_at: SystemTime,
@@ -50,7 +42,6 @@ pub struct DesktopEvent {
     pub failure: Option<ObservationFailure>,
 }
 
-#[cfg(any(target_os = "windows", test))]
 impl DesktopEvent {
     #[must_use]
     pub fn lifecycle(kind: DesktopEventKind) -> Self {
@@ -78,12 +69,11 @@ impl DesktopEvent {
 
 #[cfg(test)]
 mod tests {
-    use super::{DesktopEvent, DesktopEventKind, ObservationFailure};
+    use super::*;
 
     #[test]
     fn lifecycle_events_have_no_process_details() {
         let event = DesktopEvent::lifecycle(DesktopEventKind::SessionLocked);
-
         assert_eq!(event.kind, DesktopEventKind::SessionLocked);
         assert!(event.process.is_none());
         assert!(event.failure.is_none());
@@ -92,7 +82,6 @@ mod tests {
     #[test]
     fn unidentified_foreground_event_preserves_failure() {
         let event = DesktopEvent::foreground(None, Some(ObservationFailure::ProcessOpenFailed(5)));
-
         assert_eq!(event.kind, DesktopEventKind::ForegroundChanged);
         assert_eq!(
             event.failure,

--- a/src-tauri/src/platform/noop.rs
+++ b/src-tauri/src/platform/noop.rs
@@ -1,6 +1,12 @@
+use std::sync::mpsc;
+
+use super::DesktopEvent;
+
 #[derive(Debug)]
 pub struct EventProbe;
 
-pub fn start_event_probe() -> Result<EventProbe, String> {
-    Ok(EventProbe)
+pub fn start_event_probe() -> Result<(EventProbe, mpsc::Receiver<DesktopEvent>), String> {
+    let (sender, receiver) = mpsc::channel();
+    drop(sender);
+    Ok((EventProbe, receiver))
 }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
-use std::time::UNIX_EPOCH;
 
 use windows::core::{w, PWSTR};
 use windows::Win32::Foundation::{
@@ -38,10 +37,9 @@ static EVENT_SENDER: OnceLock<Mutex<Option<mpsc::Sender<DesktopEvent>>>> = OnceL
 pub struct EventProbe {
     observer_thread_id: u32,
     observer: Option<JoinHandle<()>>,
-    logger: Option<JoinHandle<()>>,
 }
 
-pub fn start_event_probe() -> Result<EventProbe, String> {
+pub fn start_event_probe() -> Result<(EventProbe, mpsc::Receiver<DesktopEvent>), String> {
     let (event_sender, event_receiver) = mpsc::channel();
     set_event_sender(Some(event_sender.clone()));
 
@@ -70,28 +68,13 @@ pub fn start_event_probe() -> Result<EventProbe, String> {
         }
     };
 
-    let logger = match thread::Builder::new()
-        .name("windows-event-probe-logger".to_string())
-        .spawn(move || {
-            while let Ok(event) = event_receiver.recv() {
-                log_event(&event);
-            }
-        }) {
-        Ok(logger) => logger,
-        Err(err) => {
-            // SAFETY: observer_thread_id was reported by the running message-loop thread.
-            let _ =
-                unsafe { PostThreadMessageW(observer_thread_id, WM_QUIT, WPARAM(0), LPARAM(0)) };
-            let _ = observer.join();
-            return Err(format!("failed to spawn Windows event logger: {err}"));
-        }
-    };
-
-    Ok(EventProbe {
-        observer_thread_id,
-        observer: Some(observer),
-        logger: Some(logger),
-    })
+    Ok((
+        EventProbe {
+            observer_thread_id,
+            observer: Some(observer),
+        },
+        event_receiver,
+    ))
 }
 
 impl Drop for EventProbe {
@@ -101,9 +84,6 @@ impl Drop for EventProbe {
             unsafe { PostThreadMessageW(self.observer_thread_id, WM_QUIT, WPARAM(0), LPARAM(0)) };
         if let Some(observer) = self.observer.take() {
             let _ = observer.join();
-        }
-        if let Some(logger) = self.logger.take() {
-            let _ = logger.join();
         }
     }
 }
@@ -364,21 +344,4 @@ fn emit(event: DesktopEvent) {
             let _ = sender.send(event);
         }
     }
-}
-
-fn log_event(event: &DesktopEvent) {
-    let observed_at_ms = event
-        .observed_at
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or_default();
-    let process_id = event.process.as_ref().map(|process| process.process_id);
-    let executable = event
-        .process
-        .as_ref()
-        .map(|process| process.executable.display().to_string());
-    eprintln!(
-        "[windows-event-probe] observed_at_ms={observed_at_ms} kind={:?} pid={process_id:?} executable={executable:?} failure={:?}",
-        event.kind, event.failure
-    );
 }

--- a/src-tauri/src/usage_recorder.rs
+++ b/src-tauri/src/usage_recorder.rs
@@ -1,0 +1,426 @@
+//! Converts desktop lifecycle events into durable usage sessions.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Local, Utc};
+
+use crate::platform::{DesktopEvent, DesktopEventKind, ObservationFailure, ProcessIdentity};
+use crate::usage_history::{AppMetadata, NewUsageSession, UsageHistoryStore, UsageSubject};
+
+pub const CHECKPOINT_INTERVAL_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TrackedSubject {
+    Identified(AppMetadata),
+    Unclassified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActiveSession {
+    subject: TrackedSubject,
+    started_at_utc_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RecorderState {
+    Idle,
+    Recording(ActiveSession),
+    Interrupted,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RecorderDiagnostics {
+    pub subscription_error: Option<String>,
+    pub observation_failure: Option<ObservationFailure>,
+    pub persistence_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionRecord {
+    subject: TrackedSubject,
+    started_at_utc_ms: u64,
+    ended_at_utc_ms: u64,
+    measured_timezone: String,
+    measured_local_date: String,
+    end_reason: &'static str,
+}
+
+trait SessionSink: Send + Sync {
+    fn save(&self, session: &SessionRecord) -> Result<(), String>;
+}
+
+struct SqliteSessionSink {
+    store: Arc<UsageHistoryStore>,
+}
+
+impl SessionSink for SqliteSessionSink {
+    fn save(&self, session: &SessionRecord) -> Result<(), String> {
+        let subject = match &session.subject {
+            TrackedSubject::Identified(metadata) => UsageSubject::Identified(metadata),
+            TrackedSubject::Unclassified => UsageSubject::Unclassified,
+        };
+        self.store
+            .record_session(&NewUsageSession {
+                subject,
+                started_at_utc_ms: session.started_at_utc_ms,
+                ended_at_utc_ms: session.ended_at_utc_ms,
+                measured_timezone: &session.measured_timezone,
+                measured_local_date: &session.measured_local_date,
+                end_reason: session.end_reason,
+            })
+            .map(|_| ())
+    }
+}
+
+pub struct UsageRecorder {
+    sink: Arc<dyn SessionSink>,
+    state: Mutex<RecorderState>,
+    diagnostics: Mutex<RecorderDiagnostics>,
+}
+
+impl UsageRecorder {
+    #[must_use]
+    pub fn new(store: Arc<UsageHistoryStore>) -> Self {
+        Self::with_sink(Arc::new(SqliteSessionSink { store }))
+    }
+
+    fn with_sink(sink: Arc<dyn SessionSink>) -> Self {
+        Self {
+            sink,
+            state: Mutex::new(RecorderState::Idle),
+            diagnostics: Mutex::new(RecorderDiagnostics::default()),
+        }
+    }
+
+    pub fn handle_event(&self, event: DesktopEvent) {
+        let observed_at_utc_ms = system_time_to_ms(event.observed_at);
+        match event.kind {
+            DesktopEventKind::ForegroundChanged => {
+                self.record_observation_failure(event.failure);
+                if event
+                    .process
+                    .as_ref()
+                    .is_some_and(|process| process.process_id == std::process::id())
+                {
+                    self.exclude_focus(observed_at_utc_ms);
+                    return;
+                }
+                let subject = event
+                    .process
+                    .as_ref()
+                    .map(subject_from_process)
+                    .unwrap_or(TrackedSubject::Unclassified);
+                self.focus_changed(subject, observed_at_utc_ms);
+            }
+            DesktopEventKind::SessionLocked => {
+                self.interrupt(observed_at_utc_ms, "session_locked");
+            }
+            DesktopEventKind::Suspended => {
+                self.interrupt(observed_at_utc_ms, "system_suspended");
+            }
+            DesktopEventKind::SessionUnlocked | DesktopEventKind::Resumed => self.resume(),
+        }
+    }
+
+    pub fn checkpoint(&self, at: SystemTime) {
+        self.close_and_restart(system_time_to_ms(at), "checkpoint");
+    }
+
+    pub fn stop(&self, at: SystemTime) {
+        let at_utc_ms = system_time_to_ms(at);
+        if let Ok(mut state) = self.state.lock() {
+            if let RecorderState::Recording(active) = &*state {
+                self.persist(active, at_utc_ms, "measurement_stopped");
+            }
+            *state = RecorderState::Idle;
+        }
+    }
+
+    pub fn record_subscription_failure(&self, error: String) {
+        if let Ok(mut diagnostics) = self.diagnostics.lock() {
+            diagnostics.subscription_error = Some(error);
+        }
+    }
+
+    #[must_use]
+    pub fn diagnostics(&self) -> RecorderDiagnostics {
+        self.diagnostics
+            .lock()
+            .map(|value| value.clone())
+            .unwrap_or_else(|_| RecorderDiagnostics {
+                persistence_error: Some("usage recorder diagnostics mutex poisoned".into()),
+                ..RecorderDiagnostics::default()
+            })
+    }
+
+    fn focus_changed(&self, subject: TrackedSubject, at_utc_ms: u64) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if let RecorderState::Recording(active) = &*state {
+            if active.subject == subject {
+                return;
+            }
+            self.persist(active, at_utc_ms, "focus_changed");
+        }
+        *state = RecorderState::Recording(ActiveSession {
+            subject,
+            started_at_utc_ms: at_utc_ms,
+        });
+    }
+
+    fn exclude_focus(&self, at_utc_ms: u64) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if let RecorderState::Recording(active) = &*state {
+            self.persist(active, at_utc_ms, "focus_changed");
+        }
+        *state = RecorderState::Idle;
+    }
+
+    fn interrupt(&self, at_utc_ms: u64, reason: &'static str) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if let RecorderState::Recording(active) = &*state {
+            self.persist(active, at_utc_ms, reason);
+        }
+        *state = RecorderState::Interrupted;
+    }
+
+    fn resume(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            if matches!(*state, RecorderState::Interrupted) {
+                *state = RecorderState::Idle;
+            }
+        }
+    }
+
+    fn close_and_restart(&self, at_utc_ms: u64, reason: &'static str) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if let RecorderState::Recording(active) = &*state {
+            if at_utc_ms < active.started_at_utc_ms {
+                return;
+            }
+            self.persist(active, at_utc_ms, reason);
+            *state = RecorderState::Recording(ActiveSession {
+                subject: active.subject.clone(),
+                started_at_utc_ms: at_utc_ms,
+            });
+        }
+    }
+
+    fn persist(&self, active: &ActiveSession, ended_at_utc_ms: u64, reason: &'static str) {
+        if ended_at_utc_ms < active.started_at_utc_ms {
+            return;
+        }
+        let (measured_timezone, measured_local_date) =
+            local_measurement_context(active.started_at_utc_ms);
+        let result = self.sink.save(&SessionRecord {
+            subject: active.subject.clone(),
+            started_at_utc_ms: active.started_at_utc_ms,
+            ended_at_utc_ms,
+            measured_timezone,
+            measured_local_date,
+            end_reason: reason,
+        });
+        if let Err(error) = result {
+            if let Ok(mut diagnostics) = self.diagnostics.lock() {
+                diagnostics.persistence_error = Some(error);
+            }
+        }
+    }
+
+    fn record_observation_failure(&self, failure: Option<ObservationFailure>) {
+        if let Some(failure) = failure {
+            if let Ok(mut diagnostics) = self.diagnostics.lock() {
+                diagnostics.observation_failure = Some(failure);
+            }
+        }
+    }
+}
+
+fn subject_from_process(process: &ProcessIdentity) -> TrackedSubject {
+    let executable = process.executable.display().to_string();
+    let stable_key = executable.to_lowercase();
+    let display_name = Path::new(&process.executable)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("Unknown application")
+        .to_string();
+    TrackedSubject::Identified(AppMetadata {
+        stable_key,
+        display_name,
+        executable: Some(executable),
+    })
+}
+
+fn local_measurement_context(at_utc_ms: u64) -> (String, String) {
+    let utc = i64::try_from(at_utc_ms)
+        .ok()
+        .and_then(DateTime::<Utc>::from_timestamp_millis)
+        .unwrap_or_else(Utc::now);
+    let local = utc.with_timezone(&Local);
+    (
+        local.format("%:z").to_string(),
+        local.format("%F").to_string(),
+    )
+}
+
+fn system_time_to_ms(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[derive(Default)]
+    struct MemorySink {
+        sessions: Mutex<Vec<SessionRecord>>,
+    }
+
+    impl SessionSink for MemorySink {
+        fn save(&self, session: &SessionRecord) -> Result<(), String> {
+            self.sessions.lock().unwrap().push(session.clone());
+            Ok(())
+        }
+    }
+
+    fn at(milliseconds: u64) -> SystemTime {
+        UNIX_EPOCH + std::time::Duration::from_millis(milliseconds)
+    }
+
+    fn foreground(milliseconds: u64, executable: &str) -> DesktopEvent {
+        DesktopEvent {
+            observed_at: at(milliseconds),
+            kind: DesktopEventKind::ForegroundChanged,
+            process: Some(ProcessIdentity {
+                process_id: 42,
+                executable: PathBuf::from(executable),
+            }),
+            failure: None,
+        }
+    }
+
+    fn recorder() -> (Arc<MemorySink>, UsageRecorder) {
+        let sink = Arc::new(MemorySink::default());
+        let recorder = UsageRecorder::with_sink(sink.clone());
+        (sink, recorder)
+    }
+
+    #[test]
+    fn focus_changes_create_sessions_immediately() {
+        let (sink, recorder) = recorder();
+        recorder.handle_event(foreground(1_000, r"C:\Apps\Editor.exe"));
+        recorder.handle_event(foreground(2_500, r"C:\Apps\Browser.exe"));
+        let sessions = sink.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            (sessions[0].started_at_utc_ms, sessions[0].ended_at_utc_ms),
+            (1_000, 2_500)
+        );
+        assert_eq!(sessions[0].end_reason, "focus_changed");
+    }
+
+    #[test]
+    fn time_wise_focus_is_excluded() {
+        let (sink, recorder) = recorder();
+        recorder.handle_event(foreground(1_000, r"C:\Apps\Editor.exe"));
+        recorder.handle_event(DesktopEvent {
+            observed_at: at(2_000),
+            kind: DesktopEventKind::ForegroundChanged,
+            process: Some(ProcessIdentity {
+                process_id: std::process::id(),
+                executable: PathBuf::from(r"C:\Apps\time-wise.exe"),
+            }),
+            failure: None,
+        });
+        recorder.checkpoint(at(3_000));
+        let sessions = sink.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].ended_at_utc_ms, 2_000);
+    }
+
+    #[test]
+    fn lock_and_suspend_close_sessions_until_fresh_focus() {
+        for (kind, reason) in [
+            (DesktopEventKind::SessionLocked, "session_locked"),
+            (DesktopEventKind::Suspended, "system_suspended"),
+        ] {
+            let (sink, recorder) = recorder();
+            recorder.handle_event(foreground(1_000, r"C:\Apps\Editor.exe"));
+            recorder.handle_event(DesktopEvent {
+                observed_at: at(2_000),
+                kind,
+                process: None,
+                failure: None,
+            });
+            recorder.handle_event(DesktopEvent {
+                observed_at: at(3_000),
+                kind: DesktopEventKind::Resumed,
+                process: None,
+                failure: None,
+            });
+            recorder.checkpoint(at(4_000));
+            assert_eq!(sink.sessions.lock().unwrap().len(), 1);
+            assert_eq!(sink.sessions.lock().unwrap()[0].end_reason, reason);
+            recorder.handle_event(foreground(5_000, r"C:\Apps\Editor.exe"));
+            recorder.stop(at(6_000));
+            assert_eq!(sink.sessions.lock().unwrap().len(), 2);
+        }
+    }
+
+    #[test]
+    fn checkpoints_bound_abnormal_exit_loss_to_less_than_thirty_seconds() {
+        let (sink, recorder) = recorder();
+        recorder.handle_event(foreground(0, r"C:\Apps\Editor.exe"));
+        recorder.checkpoint(at(30_000));
+        let sessions = sink.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].ended_at_utc_ms, 30_000);
+        let simulated_crash_at_ms = 59_999;
+        assert!(simulated_crash_at_ms - sessions[0].ended_at_utc_ms < 30_000);
+    }
+
+    #[test]
+    fn normal_stop_finalizes_the_active_session() {
+        let (sink, recorder) = recorder();
+        recorder.handle_event(foreground(10, r"C:\Apps\Editor.exe"));
+        recorder.stop(at(20));
+        let sessions = sink.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].end_reason, "measurement_stopped");
+    }
+
+    #[test]
+    fn observation_and_subscription_failures_are_diagnostic() {
+        let (_sink, recorder) = recorder();
+        recorder.record_subscription_failure("hook failed".into());
+        recorder.handle_event(DesktopEvent {
+            observed_at: at(10),
+            kind: DesktopEventKind::ForegroundChanged,
+            process: None,
+            failure: Some(ObservationFailure::ProcessOpenFailed(5)),
+        });
+        let diagnostics = recorder.diagnostics();
+        assert_eq!(
+            diagnostics.subscription_error.as_deref(),
+            Some("hook failed")
+        );
+        assert_eq!(
+            diagnostics.observation_failure,
+            Some(ObservationFailure::ProcessOpenFailed(5))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- route Windows foreground and lifecycle events into a durable usage recorder
- checkpoint active sessions every 30 seconds to bound abnormal-exit loss
- close sessions on lock and suspend, then resume from a fresh foreground observation
- finalize the active session during normal application exit
- retain subscription, observation, and persistence failures as recorder diagnostics
- exclude Time Wise itself, including the initial foreground observation
- persist the measured UTC range, local offset, and local date through the SQLite history store

## Impact

Windows usage measurement now runs continuously in release builds instead of only logging events behind a debug environment flag. Active usage is durably segmented at focus changes and 30-second checkpoints, while locked and suspended time is excluded.

## Design notes

The Windows probe now returns its event receiver to the recorder rather than owning a logger thread. The recorder state machine is isolated behind a session sink so focus, lifecycle, checkpoint, shutdown, self-exclusion, and diagnostic behavior can be tested deterministically without Win32 or SQLite IO.

## Validation

- `cargo sort -w`
- `cargo fmt --all`
- `cargo clippy --workspace --bins --tests --examples -- -D rust_2018_idioms -D warnings`
- `cargo test --workspace` (45 passed)
- `cargo check -p time-wise --release`
- `git diff --check`

Closes #104
