### PR TITLE
feat: resolve Windows apps to stable product identities

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,14 +26,18 @@ tauri-plugin-opener = "2"
 tokio = { version = "1", features = ["time"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+image = { version = "0.25", default-features = false, features = ["png"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_Storage_FileSystem",
+    "Win32_Storage_Packaging_Appx",
     "Win32_System_LibraryLoader",
     "Win32_System_Power",
     "Win32_System_RemoteDesktop",
     "Win32_System_Threading",
     "Win32_UI_Accessibility",
+    "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }
 

--- a/src-tauri/src/app_identity.rs
+++ b/src-tauri/src/app_identity.rs
@@ -1,0 +1,136 @@
+//! Resolves observed Windows processes to product-level application identities.
+
+use std::path::Path;
+
+use crate::platform::ProcessIdentity;
+use crate::usage_history::AppMetadata;
+
+/// Converts the identity evidence collected by the platform adapter into a
+/// stable product key and display metadata.
+#[must_use]
+pub fn resolve(process: &ProcessIdentity) -> AppMetadata {
+    let executable = process.executable.display().to_string();
+    let display_name = process
+        .product_name
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| package_display_name(process))
+        .map(str::to_owned)
+        .unwrap_or_else(|| executable_display_name(&process.executable));
+
+    let stable_key = if let Some(package_family) = non_empty(process.package_family_name.as_deref())
+    {
+        format!("windows-package:{}", normalize_key_part(package_family))
+    } else if let Some(product_name) = non_empty(process.product_name.as_deref()) {
+        let publisher = non_empty(process.company_name.as_deref()).unwrap_or("unknown-publisher");
+        format!(
+            "windows-product:{}:{}",
+            normalize_key_part(publisher),
+            normalize_key_part(product_name)
+        )
+    } else {
+        format!("windows-executable:{}", normalize_path(&executable))
+    };
+
+    AppMetadata {
+        stable_key,
+        display_name,
+        executable: Some(executable.clone()),
+        // The dashboard can ask Windows Shell for the representative icon from
+        // this source without persisting a window title or other user content.
+        icon_source: Some(executable),
+        icon_png: process.icon_png.clone(),
+    }
+}
+
+fn package_display_name(process: &ProcessIdentity) -> Option<&str> {
+    non_empty(process.application_user_model_id.as_deref())
+        .and_then(|value| value.rsplit(['!', '.']).next())
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn executable_display_name(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("Unknown application")
+        .to_string()
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.filter(|value| !value.trim().is_empty())
+}
+
+fn normalize_key_part(value: &str) -> String {
+    value
+        .trim()
+        .to_lowercase()
+        .chars()
+        .map(|character| {
+            if character.is_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn normalize_path(value: &str) -> String {
+    value.trim().replace('/', "\\").to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn process(executable: &str) -> ProcessIdentity {
+        ProcessIdentity {
+            process_id: 42,
+            executable: PathBuf::from(executable),
+            ..ProcessIdentity::default()
+        }
+    }
+
+    #[test]
+    fn package_family_is_stable_across_processes_and_profiles() {
+        let mut browser = process(r"C:\Program Files\WindowsApps\Browser\browser.exe");
+        browser.package_family_name = Some("Example.Browser_123abc".into());
+        browser.application_user_model_id = Some("Example.Browser_123abc!Browser".into());
+
+        let mut helper = process(r"C:\Program Files\WindowsApps\Browser\helper.exe");
+        helper.package_family_name = browser.package_family_name.clone();
+        helper.application_user_model_id = browser.application_user_model_id.clone();
+
+        assert_eq!(resolve(&browser).stable_key, resolve(&helper).stable_key);
+        assert_eq!(resolve(&browser).display_name, "Browser");
+    }
+
+    #[test]
+    fn desktop_product_metadata_combines_multiple_executables() {
+        let mut editor = process(r"C:\Apps\Editor\editor.exe");
+        editor.company_name = Some("Example Corp.".into());
+        editor.product_name = Some("Example Editor".into());
+
+        let mut renderer = process(r"C:\Apps\Editor\renderer.exe");
+        renderer.company_name = editor.company_name.clone();
+        renderer.product_name = editor.product_name.clone();
+
+        assert_eq!(resolve(&editor).stable_key, resolve(&renderer).stable_key);
+        assert_eq!(resolve(&editor).display_name, "Example Editor");
+    }
+
+    #[test]
+    fn executable_path_is_a_deterministic_fallback() {
+        let upper = process(r"C:\Apps\Terminal.exe");
+        let lower = process(r"c:\apps\terminal.exe");
+
+        assert_eq!(resolve(&upper).stable_key, resolve(&lower).stable_key);
+        assert_eq!(resolve(&upper).display_name, "Terminal");
+        assert_eq!(
+            resolve(&upper).icon_source.as_deref(),
+            Some(r"C:\Apps\Terminal.exe")
+        );
+    }
+}

--- a/src-tauri/src/app_identity.rs
+++ b/src-tauri/src/app_identity.rs
@@ -50,7 +50,10 @@ fn package_display_name(process: &ProcessIdentity) -> Option<&str> {
 }
 
 fn executable_display_name(path: &Path) -> String {
-    path.file_stem()
+    let path = path.to_string_lossy();
+    let file_name = path.rsplit(['\\', '/']).next().unwrap_or_default();
+    Path::new(file_name)
+        .file_stem()
         .and_then(|name| name.to_str())
         .filter(|name| !name.trim().is_empty())
         .unwrap_or("Unknown application")
@@ -128,6 +131,10 @@ mod tests {
 
         assert_eq!(resolve(&upper).stable_key, resolve(&lower).stable_key);
         assert_eq!(resolve(&upper).display_name, "Terminal");
+        assert_eq!(
+            resolve(&process("/opt/apps/Terminal.exe")).display_name,
+            "Terminal"
+        );
         assert_eq!(
             resolve(&upper).icon_source.as_deref(),
             Some(r"C:\Apps\Terminal.exe")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_identity;
 mod app_usage;
 mod platform;
 mod startup_metrics;

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -22,10 +22,15 @@ pub enum DesktopEventKind {
     Resumed,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ProcessIdentity {
     pub process_id: u32,
     pub executable: PathBuf,
+    pub package_family_name: Option<String>,
+    pub application_user_model_id: Option<String>,
+    pub product_name: Option<String>,
+    pub company_name: Option<String>,
+    pub icon_png: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -1,11 +1,24 @@
-use std::path::PathBuf;
+use std::ffi::{c_void, OsStr};
+use std::io::Cursor;
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 
-use windows::core::{w, PWSTR};
+use image::{DynamicImage, ImageBuffer, ImageFormat, Rgba};
+use windows::core::{w, PCWSTR, PWSTR};
 use windows::Win32::Foundation::{
-    CloseHandle, GetLastError, HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM,
+    CloseHandle, GetLastError, APPMODEL_ERROR_NO_PACKAGE, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS,
+    HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, WIN32_ERROR, WPARAM,
 };
+use windows::Win32::Graphics::Gdi::{
+    CreateCompatibleDC, CreateDIBSection, DeleteDC, DeleteObject, SelectObject, BITMAPINFO,
+    BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HGDIOBJ,
+};
+use windows::Win32::Storage::FileSystem::{
+    GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, FILE_FLAGS_AND_ATTRIBUTES,
+};
+use windows::Win32::Storage::Packaging::Appx::{GetApplicationUserModelId, GetPackageFamilyName};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Power::{
     RegisterSuspendResumeNotification, UnregisterSuspendResumeNotification, HPOWERNOTIFY,
@@ -18,18 +31,21 @@ use windows::Win32::System::Threading::{
     PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::Accessibility::{SetWinEventHook, UnhookWinEvent, HWINEVENTHOOK};
+use windows::Win32::UI::Shell::{SHGetFileInfoW, SHFILEINFOW, SHGFI_ICON, SHGFI_LARGEICON};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetForegroundWindow,
-    GetMessageW, GetWindowThreadProcessId, PostThreadMessageW, RegisterClassW, TranslateMessage,
-    UnregisterClassW, DEVICE_NOTIFY_WINDOW_HANDLE, EVENT_SYSTEM_FOREGROUND, MSG,
-    PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND, PBT_APMSUSPEND, WINDOW_EX_STYLE, WINDOW_STYLE,
-    WINEVENT_OUTOFCONTEXT, WINEVENT_SKIPOWNPROCESS, WM_POWERBROADCAST, WM_QUIT,
-    WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_SESSION_LOCK, WTS_SESSION_UNLOCK,
+    CreateWindowExW, DefWindowProcW, DestroyIcon, DestroyWindow, DispatchMessageW, DrawIconEx,
+    GetForegroundWindow, GetMessageW, GetWindowThreadProcessId, PostThreadMessageW, RegisterClassW,
+    TranslateMessage, UnregisterClassW, DEVICE_NOTIFY_WINDOW_HANDLE, DI_NORMAL,
+    EVENT_SYSTEM_FOREGROUND, MSG, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND, PBT_APMSUSPEND,
+    WINDOW_EX_STYLE, WINDOW_STYLE, WINEVENT_OUTOFCONTEXT, WINEVENT_SKIPOWNPROCESS,
+    WM_POWERBROADCAST, WM_QUIT, WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_SESSION_LOCK,
+    WTS_SESSION_UNLOCK,
 };
 
 use super::{DesktopEvent, DesktopEventKind, ObservationFailure, ProcessIdentity};
 
 const MAX_EXECUTABLE_PATH: usize = 32_768;
+const APP_ICON_SIZE: u32 = 32;
 
 static EVENT_SENDER: OnceLock<Mutex<Option<mpsc::Sender<DesktopEvent>>>> = OnceLock::new();
 
@@ -292,23 +308,27 @@ fn observe_window(window: HWND) -> DesktopEvent {
         return DesktopEvent::foreground(None, Some(ObservationFailure::ProcessIdUnavailable));
     }
 
-    match executable_path(process_id) {
-        Ok(executable) => DesktopEvent::foreground(
-            Some(ProcessIdentity {
-                process_id,
-                executable,
-            }),
-            None,
-        ),
+    match process_identity(process_id) {
+        Ok(process) => DesktopEvent::foreground(Some(process), None),
         Err(failure) => DesktopEvent::foreground(None, Some(failure)),
     }
 }
 
-fn executable_path(process_id: u32) -> Result<PathBuf, ObservationFailure> {
+fn process_identity(process_id: u32) -> Result<ProcessIdentity, ObservationFailure> {
     // SAFETY: process_id is supplied by Windows for the foreground HWND.
     let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id) }
         .map_err(|err| ObservationFailure::ProcessOpenFailed(err.code().0 as u32))?;
 
+    let result = process_identity_from_handle(process_id, process);
+    // SAFETY: process was returned by OpenProcess and is closed exactly once.
+    let _ = unsafe { CloseHandle(process) };
+    result
+}
+
+fn process_identity_from_handle(
+    process_id: u32,
+    process: HANDLE,
+) -> Result<ProcessIdentity, ObservationFailure> {
     let mut buffer = vec![0u16; MAX_EXECUTABLE_PATH];
     let mut length = buffer.len() as u32;
     // SAFETY: buffer is writable for length UTF-16 code units and process is a valid handle.
@@ -320,12 +340,244 @@ fn executable_path(process_id: u32) -> Result<PathBuf, ObservationFailure> {
             &mut length,
         )
     };
-    // SAFETY: process was returned by OpenProcess and is closed exactly once.
-    let _ = unsafe { CloseHandle(process) };
-
     result.map_err(|err| ObservationFailure::ExecutablePathUnavailable(err.code().0 as u32))?;
     buffer.truncate(length as usize);
-    Ok(PathBuf::from(String::from_utf16_lossy(&buffer)))
+    let executable = PathBuf::from(String::from_utf16_lossy(&buffer));
+    let package_family_name = query_app_model_value(process, GetPackageFamilyName);
+    let application_user_model_id = query_app_model_value(process, GetApplicationUserModelId);
+    let (product_name, company_name) = file_version_metadata(&executable);
+    let icon_png = executable_icon_png(&executable);
+
+    Ok(ProcessIdentity {
+        process_id,
+        executable,
+        package_family_name,
+        application_user_model_id,
+        product_name,
+        company_name,
+        icon_png,
+    })
+}
+
+type AppModelQuery = unsafe fn(HANDLE, *mut u32, Option<PWSTR>) -> WIN32_ERROR;
+
+fn query_app_model_value(process: HANDLE, query: AppModelQuery) -> Option<String> {
+    let mut length = 0;
+    // SAFETY: the first call requests the required UTF-16 buffer length only.
+    let status = unsafe { query(process, &mut length, None) };
+    if status == APPMODEL_ERROR_NO_PACKAGE {
+        return None;
+    }
+    if status != ERROR_INSUFFICIENT_BUFFER && status != ERROR_SUCCESS {
+        return None;
+    }
+    if length == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; length as usize];
+    // SAFETY: buffer contains length writable UTF-16 code units as requested above.
+    let status = unsafe { query(process, &mut length, Some(PWSTR(buffer.as_mut_ptr()))) };
+    if status != ERROR_SUCCESS {
+        return None;
+    }
+    buffer.truncate(length as usize);
+    if buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    let value = String::from_utf16_lossy(&buffer);
+    (!value.trim().is_empty()).then_some(value)
+}
+
+fn file_version_metadata(executable: &Path) -> (Option<String>, Option<String>) {
+    let wide_path = wide(executable.as_os_str());
+    // SAFETY: wide_path is a null-terminated UTF-16 path valid for this call.
+    let size = unsafe { GetFileVersionInfoSizeW(PCWSTR(wide_path.as_ptr()), None) };
+    if size == 0 {
+        return (None, None);
+    }
+
+    let mut data = vec![0u8; size as usize];
+    // SAFETY: data provides exactly size writable bytes and wide_path remains alive.
+    if unsafe {
+        GetFileVersionInfoW(
+            PCWSTR(wide_path.as_ptr()),
+            None,
+            size,
+            data.as_mut_ptr().cast(),
+        )
+    }
+    .is_err()
+    {
+        return (None, None);
+    }
+
+    let (language, code_page) = version_translation(&data).unwrap_or((0x0409, 0x04b0));
+    (
+        version_string(&data, language, code_page, "ProductName"),
+        version_string(&data, language, code_page, "CompanyName"),
+    )
+}
+
+fn version_translation(data: &[u8]) -> Option<(u16, u16)> {
+    let query = wide(OsStr::new(r"\VarFileInfo\Translation"));
+    let mut value = std::ptr::null_mut::<c_void>();
+    let mut length = 0;
+    // SAFETY: data is the version-info block returned by Windows; value and length are outputs.
+    let found = unsafe {
+        VerQueryValueW(
+            data.as_ptr().cast(),
+            PCWSTR(query.as_ptr()),
+            &mut value,
+            &mut length,
+        )
+    };
+    if !found.as_bool() || value.is_null() || length < 4 {
+        return None;
+    }
+    // SAFETY: VerQueryValueW returned at least four bytes containing two WORD values.
+    let words = unsafe { std::slice::from_raw_parts(value.cast::<u16>(), 2) };
+    Some((words[0], words[1]))
+}
+
+fn version_string(data: &[u8], language: u16, code_page: u16, name: &str) -> Option<String> {
+    let sub_block = format!(r"\StringFileInfo\{language:04x}{code_page:04x}\{name}");
+    let query = wide(OsStr::new(&sub_block));
+    let mut value = std::ptr::null_mut::<c_void>();
+    let mut length = 0;
+    // SAFETY: data is the version-info block returned by Windows; value and length are outputs.
+    let found = unsafe {
+        VerQueryValueW(
+            data.as_ptr().cast(),
+            PCWSTR(query.as_ptr()),
+            &mut value,
+            &mut length,
+        )
+    };
+    if !found.as_bool() || value.is_null() || length == 0 {
+        return None;
+    }
+    // SAFETY: Windows reports length in UTF-16 code units for version string values.
+    let units = unsafe { std::slice::from_raw_parts(value.cast::<u16>(), length as usize) };
+    let value = String::from_utf16_lossy(units)
+        .trim_end_matches('\0')
+        .trim()
+        .to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn executable_icon_png(executable: &Path) -> Option<Vec<u8>> {
+    let wide_path = wide(executable.as_os_str());
+    let mut file_info = SHFILEINFOW::default();
+    // SAFETY: wide_path is a null-terminated path and file_info is writable for its full size.
+    let result = unsafe {
+        SHGetFileInfoW(
+            PCWSTR(wide_path.as_ptr()),
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            Some(&mut file_info),
+            std::mem::size_of::<SHFILEINFOW>() as u32,
+            SHGFI_ICON | SHGFI_LARGEICON,
+        )
+    };
+    if result == 0 || file_info.hIcon.0.is_null() {
+        return None;
+    }
+
+    let png = icon_to_png(file_info.hIcon);
+    // SAFETY: SHGetFileInfoW returned ownership of this icon handle to the caller.
+    let _ = unsafe { DestroyIcon(file_info.hIcon) };
+    png
+}
+
+fn icon_to_png(icon: windows::Win32::UI::WindowsAndMessaging::HICON) -> Option<Vec<u8>> {
+    // SAFETY: a memory DC has no lifetime dependency on a window.
+    let dc = unsafe { CreateCompatibleDC(None) };
+    if dc.0.is_null() {
+        return None;
+    }
+
+    let bitmap_info = BITMAPINFO {
+        bmiHeader: BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: APP_ICON_SIZE as i32,
+            // A negative height creates a top-down DIB, matching PNG row order.
+            biHeight: -(APP_ICON_SIZE as i32),
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB.0,
+            ..BITMAPINFOHEADER::default()
+        },
+        ..BITMAPINFO::default()
+    };
+    let mut pixels = std::ptr::null_mut::<c_void>();
+    // SAFETY: bitmap_info is initialized and pixels receives the DIB allocation address.
+    let bitmap = match unsafe {
+        CreateDIBSection(Some(dc), &bitmap_info, DIB_RGB_COLORS, &mut pixels, None, 0)
+    } {
+        Ok(bitmap) => bitmap,
+        Err(_) => {
+            // SAFETY: dc was created above and has no selected resources to release first.
+            let _ = unsafe { DeleteDC(dc) };
+            return None;
+        }
+    };
+    // SAFETY: bitmap is a valid GDI bitmap and dc is a compatible memory DC.
+    let previous = unsafe { SelectObject(dc, HGDIOBJ(bitmap.0)) };
+    // SAFETY: dc owns a selected 32-bit DIB and icon is a valid shell icon handle.
+    let drawn = unsafe {
+        DrawIconEx(
+            dc,
+            0,
+            0,
+            icon,
+            APP_ICON_SIZE as i32,
+            APP_ICON_SIZE as i32,
+            0,
+            None,
+            DI_NORMAL,
+        )
+    }
+    .is_ok();
+
+    let rgba = if drawn && !pixels.is_null() {
+        let byte_count = (APP_ICON_SIZE * APP_ICON_SIZE * 4) as usize;
+        // SAFETY: CreateDIBSection allocated byte_count bytes for the configured 32-bit DIB.
+        let bgra = unsafe { std::slice::from_raw_parts(pixels.cast::<u8>(), byte_count) };
+        let mut rgba = bgra.to_vec();
+        for pixel in rgba.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+        }
+        if rgba.chunks_exact(4).all(|pixel| pixel[3] == 0) {
+            for pixel in rgba.chunks_exact_mut(4) {
+                if pixel[..3] != [0, 0, 0] {
+                    pixel[3] = u8::MAX;
+                }
+            }
+        }
+        Some(rgba)
+    } else {
+        None
+    };
+
+    // SAFETY: restore the prior object before deleting the DIB and memory DC.
+    unsafe {
+        if !previous.0.is_null() {
+            SelectObject(dc, previous);
+        }
+        let _ = DeleteObject(HGDIOBJ(bitmap.0));
+        let _ = DeleteDC(dc);
+    }
+
+    let image = ImageBuffer::<Rgba<u8>, _>::from_raw(APP_ICON_SIZE, APP_ICON_SIZE, rgba?)?;
+    let mut output = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(image)
+        .write_to(&mut output, ImageFormat::Png)
+        .ok()?;
+    Some(output.into_inner())
+}
+
+fn wide(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(std::iter::once(0)).collect()
 }
 
 fn set_event_sender(sender: Option<mpsc::Sender<DesktopEvent>>) {

--- a/src-tauri/src/usage_history.rs
+++ b/src-tauri/src/usage_history.rs
@@ -8,6 +8,8 @@ pub struct AppMetadata {
     pub stable_key: String,
     pub display_name: String,
     pub executable: Option<String>,
+    pub icon_source: Option<String>,
+    pub icon_png: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +33,8 @@ pub struct StoredUsageSession {
     pub stable_key: Option<String>,
     pub display_name: Option<String>,
     pub executable: Option<String>,
+    pub icon_source: Option<String>,
+    pub icon_png: Option<Vec<u8>>,
     pub started_at_utc_ms: u64,
     pub ended_at_utc_ms: u64,
     pub measured_timezone: String,
@@ -69,6 +73,8 @@ impl UsageHistoryStore {
                 stable_key TEXT NOT NULL UNIQUE,
                 display_name TEXT NOT NULL,
                 executable TEXT,
+                icon_source TEXT,
+                icon_png BLOB,
                 updated_at_utc_ms INTEGER NOT NULL
             );
             CREATE TABLE IF NOT EXISTS usage_sessions (
@@ -99,7 +105,35 @@ impl UsageHistoryStore {
             INSERT OR IGNORE INTO schema_migrations (version, applied_at_utc_ms)
                 VALUES (1, CAST(unixepoch('subsec') * 1000 AS INTEGER));
             COMMIT;",
-        )
+        )?;
+
+        Self::ensure_app_metadata_column(connection, "icon_source", "TEXT", 2)?;
+        Self::ensure_app_metadata_column(connection, "icon_png", "BLOB", 3)?;
+        Ok(())
+    }
+
+    fn ensure_app_metadata_column(
+        connection: &Connection,
+        column: &str,
+        sql_type: &str,
+        version: i64,
+    ) -> rusqlite::Result<()> {
+        let columns = connection
+            .prepare("PRAGMA table_info(app_identities)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if !columns.iter().any(|existing| existing == column) {
+            connection.execute(
+                &format!("ALTER TABLE app_identities ADD COLUMN {column} {sql_type}"),
+                [],
+            )?;
+        }
+        connection.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at_utc_ms)
+                VALUES (?1, CAST(unixepoch('subsec') * 1000 AS INTEGER))",
+            [version],
+        )?;
+        Ok(())
     }
 
     pub fn record_session(&self, session: &NewUsageSession<'_>) -> Result<i64, String> {
@@ -151,16 +185,27 @@ impl UsageHistoryStore {
     ) -> Result<i64, String> {
         non_empty("stable key", &metadata.stable_key)?;
         non_empty("display name", &metadata.display_name)?;
-        transaction.execute(
-            "INSERT INTO app_identities (stable_key, display_name, executable, updated_at_utc_ms)
-             VALUES (?1, ?2, ?3, ?4)
+        transaction
+            .execute(
+                "INSERT INTO app_identities (
+                stable_key, display_name, executable, icon_source, icon_png, updated_at_utc_ms
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(stable_key) DO UPDATE SET
                 display_name = excluded.display_name,
                 executable = excluded.executable,
+                icon_source = COALESCE(excluded.icon_source, app_identities.icon_source),
+                icon_png = COALESCE(excluded.icon_png, app_identities.icon_png),
                 updated_at_utc_ms = excluded.updated_at_utc_ms",
-            params![metadata.stable_key, metadata.display_name, metadata.executable,
-                sql_timestamp(updated_at_utc_ms)?],
-        ).map_err(|error| error.to_string())?;
+                params![
+                    metadata.stable_key,
+                    metadata.display_name,
+                    metadata.executable,
+                    metadata.icon_source,
+                    metadata.icon_png,
+                    sql_timestamp(updated_at_utc_ms)?
+                ],
+            )
+            .map_err(|error| error.to_string())?;
         transaction
             .query_row(
                 "SELECT id FROM app_identities WHERE stable_key = ?1",
@@ -177,7 +222,8 @@ impl UsageHistoryStore {
             .map_err(|_| "usage history mutex poisoned".to_string())?;
         let mut statement = connection
             .prepare(
-                "SELECT apps.stable_key, apps.display_name, apps.executable,
+                "SELECT apps.stable_key, apps.display_name, apps.executable, apps.icon_source,
+                apps.icon_png,
                 sessions.started_at_utc_ms, sessions.ended_at_utc_ms,
                 sessions.measured_timezone, sessions.measured_local_date, sessions.end_reason
              FROM usage_sessions AS sessions
@@ -192,11 +238,13 @@ impl UsageHistoryStore {
                     stable_key: row.get(0)?,
                     display_name: row.get(1)?,
                     executable: row.get(2)?,
-                    started_at_utc_ms: row.get::<_, i64>(3)?.max(0) as u64,
-                    ended_at_utc_ms: row.get::<_, i64>(4)?.max(0) as u64,
-                    measured_timezone: row.get(5)?,
-                    measured_local_date: row.get(6)?,
-                    end_reason: row.get(7)?,
+                    icon_source: row.get(3)?,
+                    icon_png: row.get(4)?,
+                    started_at_utc_ms: row.get::<_, i64>(5)?.max(0) as u64,
+                    ended_at_utc_ms: row.get::<_, i64>(6)?.max(0) as u64,
+                    measured_timezone: row.get(7)?,
+                    measured_local_date: row.get(8)?,
+                    end_reason: row.get(9)?,
                 })
             })
             .map_err(|error| error.to_string())?;
@@ -276,6 +324,8 @@ mod tests {
             stable_key: "product:editor".into(),
             display_name: "Editor".into(),
             executable: Some("editor.exe".into()),
+            icon_source: Some("editor.exe".into()),
+            icon_png: Some(vec![137, 80, 78, 71]),
         };
         store
             .record_session(&NewUsageSession {
@@ -301,6 +351,11 @@ mod tests {
         assert_eq!(sessions.len(), 2);
         assert_eq!(sessions[0].stable_key.as_deref(), Some("product:editor"));
         assert_eq!(sessions[0].display_name.as_deref(), Some("Editor"));
+        assert_eq!(sessions[0].icon_source.as_deref(), Some("editor.exe"));
+        assert_eq!(
+            sessions[0].icon_png.as_deref(),
+            Some([137, 80, 78, 71].as_slice())
+        );
         assert_eq!(sessions[1].stable_key, None);
     }
 
@@ -311,11 +366,15 @@ mod tests {
             stable_key: "product:browser".into(),
             display_name: "Old Name".into(),
             executable: None,
+            icon_source: None,
+            icon_png: None,
         };
         let updated = AppMetadata {
             stable_key: "product:browser".into(),
             display_name: "Browser".into(),
             executable: Some("browser.exe".into()),
+            icon_source: Some("browser.exe".into()),
+            icon_png: Some(vec![1, 2, 3]),
         };
         for (app, start) in [(&first, 10), (&updated, 20)] {
             store
@@ -336,6 +395,9 @@ mod tests {
         assert!(sessions
             .iter()
             .all(|session| session.executable.as_deref() == Some("browser.exe")));
+        assert!(sessions
+            .iter()
+            .all(|session| session.icon_png.as_deref() == Some([1, 2, 3].as_slice())));
     }
 
     #[test]
@@ -344,6 +406,42 @@ mod tests {
         store.set_setting("autostart", "false", 10).unwrap();
         store.set_setting("autostart", "true", 20).unwrap();
         assert_eq!(store.setting("autostart").unwrap().as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn migrates_existing_identity_metadata_cache() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("usage.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    applied_at_utc_ms INTEGER NOT NULL
+                );
+                CREATE TABLE app_identities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stable_key TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL,
+                    executable TEXT,
+                    updated_at_utc_ms INTEGER NOT NULL
+                );
+                INSERT INTO schema_migrations VALUES (1, 0);",
+            )
+            .unwrap();
+        drop(connection);
+
+        let store = UsageHistoryStore::with_storage_path(path).unwrap();
+        let connection = store.connection.lock().unwrap();
+        let columns = connection
+            .prepare("PRAGMA table_info(app_identities)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert!(columns.iter().any(|column| column == "icon_source"));
+        assert!(columns.iter().any(|column| column == "icon_png"));
     }
 
     #[test]

--- a/src-tauri/src/usage_recorder.rs
+++ b/src-tauri/src/usage_recorder.rs
@@ -1,12 +1,14 @@
 //! Converts desktop lifecycle events into durable usage sessions.
 
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Local, Utc};
 
-use crate::platform::{DesktopEvent, DesktopEventKind, ObservationFailure, ProcessIdentity};
+use crate::app_identity;
+#[cfg(test)]
+use crate::platform::ProcessIdentity;
+use crate::platform::{DesktopEvent, DesktopEventKind, ObservationFailure};
 use crate::usage_history::{AppMetadata, NewUsageSession, UsageHistoryStore, UsageSubject};
 
 pub const CHECKPOINT_INTERVAL_SECONDS: u64 = 30;
@@ -115,7 +117,7 @@ impl UsageRecorder {
                 let subject = event
                     .process
                     .as_ref()
-                    .map(subject_from_process)
+                    .map(|process| TrackedSubject::Identified(app_identity::resolve(process)))
                     .unwrap_or(TrackedSubject::Unclassified);
                 self.focus_changed(subject, observed_at_utc_ms);
             }
@@ -261,22 +263,6 @@ impl UsageRecorder {
     }
 }
 
-fn subject_from_process(process: &ProcessIdentity) -> TrackedSubject {
-    let executable = process.executable.display().to_string();
-    let stable_key = executable.to_lowercase();
-    let display_name = Path::new(&process.executable)
-        .file_stem()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.trim().is_empty())
-        .unwrap_or("Unknown application")
-        .to_string();
-    TrackedSubject::Identified(AppMetadata {
-        stable_key,
-        display_name,
-        executable: Some(executable),
-    })
-}
-
 fn local_measurement_context(at_utc_ms: u64) -> (String, String) {
     let utc = i64::try_from(at_utc_ms)
         .ok()
@@ -324,6 +310,7 @@ mod tests {
             process: Some(ProcessIdentity {
                 process_id: 42,
                 executable: PathBuf::from(executable),
+                ..ProcessIdentity::default()
             }),
             failure: None,
         }
@@ -359,6 +346,7 @@ mod tests {
             process: Some(ProcessIdentity {
                 process_id: std::process::id(),
                 executable: PathBuf::from(r"C:\Apps\time-wise.exe"),
+                ..ProcessIdentity::default()
             }),
             failure: None,
         });
@@ -452,10 +440,11 @@ mod tests {
         assert_eq!(sessions.len(), 2);
         assert_eq!(
             sessions[1].subject,
-            subject_from_process(&ProcessIdentity {
+            TrackedSubject::Identified(app_identity::resolve(&ProcessIdentity {
                 process_id: 42,
                 executable: PathBuf::from(r"C:\Apps\Browser.exe"),
-            })
+                ..ProcessIdentity::default()
+            }))
         );
         assert_eq!(sessions[1].ended_at_utc_ms, 30_000);
     }


### PR DESCRIPTION
## Summary

- resolve packaged Windows apps with Package Family Name and AUMID evidence
- resolve desktop apps with version-resource product and company metadata, with a deterministic executable-path fallback
- extract a representative 32 px PNG icon through Windows Shell
- persist display metadata and icons in SQLite with migrations for existing databases
- route foreground observations through the product identity resolver before recording usage sessions

## Impact

Usage sessions can now aggregate multiple processes and profiles belonging to the same Windows product instead of relying only on executable paths. Metadata remains local, and the resolver does not collect window titles, URLs, document names, or other user content.

Previously recorded sessions automatically reflect later display-name or icon enrichment through the shared stable identity record.

## Validation

- `cargo +1.95.0 fmt --all`
- `cargo sort -w`
- `cargo +1.95.0 clippy --workspace --bins --tests --examples -- -D rust_2018_idioms -D warnings`
- `cargo +1.95.0 test --workspace` (51 passed)
- `git diff --check`

## Remaining manual verification

- confirm packaged and elevated application identity behavior on physical Windows 11 hardware
- visually inspect extracted icons for representative desktop and packaged applications

Refs #105