### PR TITLE
feat: add onboarding and data deletion settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,8 @@ pub const TRAY_QUIT_ID: &str = "quit";
 pub const TRAY_OPEN_ID: &str = "toggle";
 /// 設定画面表示用 ID
 pub const TRAY_SETTINGS_ID: &str = "settings";
+const AUTOSTART_SETTING: &str = "autostart";
+const ONBOARDING_COMPLETED_SETTING: &str = "onboarding_completed";
 
 struct UsageWindowState {
     visible: AtomicBool,
@@ -135,7 +137,7 @@ fn show_settings_window(app: &tauri::AppHandle) {
         WebviewUrl::App("/?view=settings".into()),
     )
     .title("Time Wise Settings")
-    .inner_size(420.0, 420.0)
+    .inner_size(520.0, 650.0)
     .resizable(false)
     .skip_taskbar(false)
     .visible(true)
@@ -150,8 +152,39 @@ async fn get_autostart_enabled(autostart: State<'_, AutoLaunchManager>) -> Resul
 #[tauri::command]
 async fn set_autostart_enabled(
     autostart: State<'_, AutoLaunchManager>,
+    history: State<'_, Arc<UsageHistoryStore>>,
     enabled: bool,
 ) -> Result<bool, String> {
+    let enabled = update_autostart(&autostart, enabled)?;
+    history.set_setting(AUTOSTART_SETTING, &enabled.to_string(), current_utc_ms())?;
+    Ok(enabled)
+}
+
+#[tauri::command]
+fn get_onboarding_completed(history: State<'_, Arc<UsageHistoryStore>>) -> Result<bool, String> {
+    history
+        .setting(ONBOARDING_COMPLETED_SETTING)
+        .map(|value| value.as_deref() == Some("true"))
+}
+
+#[tauri::command]
+fn complete_onboarding(
+    autostart: State<'_, AutoLaunchManager>,
+    history: State<'_, Arc<UsageHistoryStore>>,
+    enable_autostart: bool,
+) -> Result<(), String> {
+    let enabled = update_autostart(&autostart, enable_autostart)?;
+    let now = current_utc_ms();
+    history.set_setting(AUTOSTART_SETTING, &enabled.to_string(), now)?;
+    history.set_setting(ONBOARDING_COMPLETED_SETTING, "true", now)
+}
+
+#[tauri::command]
+fn delete_all_usage_history(recorder: State<'_, Arc<UsageRecorder>>) -> Result<(), String> {
+    recorder.delete_history(SystemTime::now())
+}
+
+fn update_autostart(autostart: &AutoLaunchManager, enabled: bool) -> Result<bool, String> {
     let result = if enabled {
         autostart.enable()
     } else {
@@ -161,6 +194,14 @@ async fn set_autostart_enabled(
     result
         .and_then(|_| autostart.is_enabled())
         .map_err(|err| err.to_string())
+}
+
+fn current_utc_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -174,15 +215,19 @@ pub fn run() {
             None,
         ))
         .invoke_handler(tauri::generate_handler![
+            complete_onboarding,
+            delete_all_usage_history,
             fetch_app_usage_records,
             fetch_daily_usage_summary,
             fetch_startup_records,
             fetch_weekly_usage_summary,
             get_autostart_enabled,
+            get_onboarding_completed,
             set_autostart_enabled
         ])
         .setup(|app| {
             app.manage(UsageWindowState::default());
+            let mut onboarding_required = true;
 
             let app_usage_recorder = AppUsageRecorder::default();
             if let Err(err) = app_usage_recorder.record_current_processes() {
@@ -220,6 +265,10 @@ pub fn run() {
                 });
             match UsageHistoryStore::with_storage_path(usage_history_path) {
                 Ok(store) => {
+                    onboarding_required = store
+                        .setting(ONBOARDING_COMPLETED_SETTING)
+                        .map(|value| value.as_deref() != Some("true"))
+                        .unwrap_or(true);
                     let store = Arc::new(store);
                     let recorder = Arc::new(UsageRecorder::new(store.clone()));
                     app.manage(store);
@@ -259,7 +308,7 @@ pub fn run() {
                 WebviewUrl::App("/?view=settings".into()),
             )
             .title("Time Wise Settings")
-            .inner_size(420.0, 420.0)
+            .inner_size(520.0, 650.0)
             .resizable(false)
             .visible(false)
             .skip_taskbar(false)
@@ -362,20 +411,29 @@ pub fn run() {
                 .build(app)?;
 
             if let Some(window) = app.get_webview_window("main") {
-                #[cfg(target_os = "macos")]
-                {
-                    let _ = window.set_skip_taskbar(true);
-                }
-
-                #[cfg(not(target_os = "macos"))]
-                {
+                if onboarding_required {
                     let _ = window.set_skip_taskbar(false);
-                    let _ = window.hide();
-                }
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                    app.state::<UsageWindowState>()
+                        .visible
+                        .store(true, Ordering::SeqCst);
+                } else {
+                    #[cfg(target_os = "macos")]
+                    {
+                        let _ = window.set_skip_taskbar(true);
+                    }
 
-                app.state::<UsageWindowState>()
-                    .visible
-                    .store(false, Ordering::SeqCst);
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        let _ = window.set_skip_taskbar(false);
+                        let _ = window.hide();
+                    }
+
+                    app.state::<UsageWindowState>()
+                        .visible
+                        .store(false, Ordering::SeqCst);
+                }
             }
             Ok(())
         })

--- a/src-tauri/src/usage_history.rs
+++ b/src-tauri/src/usage_history.rs
@@ -294,6 +294,24 @@ impl UsageHistoryStore {
             .optional()
             .map_err(|error| error.to_string())
     }
+
+    /// Removes all measured usage while preserving application settings.
+    pub fn delete_all_usage_history(&self) -> Result<(), String> {
+        let mut connection = self
+            .connection
+            .lock()
+            .map_err(|_| "usage history mutex poisoned".to_string())?;
+        let transaction = connection
+            .transaction()
+            .map_err(|error| error.to_string())?;
+        transaction
+            .execute("DELETE FROM usage_sessions", [])
+            .map_err(|error| error.to_string())?;
+        transaction
+            .execute("DELETE FROM app_identities", [])
+            .map_err(|error| error.to_string())?;
+        transaction.commit().map_err(|error| error.to_string())
+    }
 }
 
 fn validate_session(session: &NewUsageSession<'_>) -> Result<(), String> {
@@ -417,6 +435,47 @@ mod tests {
         store.set_setting("autostart", "false", 10).unwrap();
         store.set_setting("autostart", "true", 20).unwrap();
         assert_eq!(store.setting("autostart").unwrap().as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn deleting_history_preserves_settings_and_removes_identity_metadata() {
+        let (_directory, store) = store();
+        let app = AppMetadata {
+            stable_key: "product:editor".into(),
+            display_name: "Editor".into(),
+            executable: Some("editor.exe".into()),
+            icon_source: None,
+            icon_png: None,
+        };
+        store
+            .record_session(&NewUsageSession {
+                subject: UsageSubject::Identified(&app),
+                started_at_utc_ms: 1_000,
+                ended_at_utc_ms: 2_000,
+                measured_timezone: "UTC",
+                measured_local_date: "2026-08-04",
+                end_reason: "focus_changed",
+            })
+            .unwrap();
+        store
+            .set_setting("onboarding_completed", "true", 2_000)
+            .unwrap();
+
+        store.delete_all_usage_history().unwrap();
+
+        assert!(store
+            .sessions_for_local_date("2026-08-04")
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store.setting("onboarding_completed").unwrap().as_deref(),
+            Some("true")
+        );
+        let connection = store.connection.lock().unwrap();
+        let identity_count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM app_identities", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(identity_count, 0);
     }
 
     #[test]

--- a/src-tauri/src/usage_recorder.rs
+++ b/src-tauri/src/usage_recorder.rs
@@ -78,6 +78,7 @@ impl SessionSink for SqliteSessionSink {
 
 pub struct UsageRecorder {
     sink: Arc<dyn SessionSink>,
+    history_store: Option<Arc<UsageHistoryStore>>,
     state: Mutex<RecorderState>,
     diagnostics: Mutex<RecorderDiagnostics>,
     last_event_at_ms: Mutex<Option<u64>>,
@@ -86,12 +87,22 @@ pub struct UsageRecorder {
 impl UsageRecorder {
     #[must_use]
     pub fn new(store: Arc<UsageHistoryStore>) -> Self {
-        Self::with_sink(Arc::new(SqliteSessionSink { store }))
+        Self {
+            sink: Arc::new(SqliteSessionSink {
+                store: store.clone(),
+            }),
+            history_store: Some(store),
+            state: Mutex::new(RecorderState::Idle),
+            diagnostics: Mutex::new(RecorderDiagnostics::default()),
+            last_event_at_ms: Mutex::new(None),
+        }
     }
 
+    #[cfg(test)]
     fn with_sink(sink: Arc<dyn SessionSink>) -> Self {
         Self {
             sink,
+            history_store: None,
             state: Mutex::new(RecorderState::Idle),
             diagnostics: Mutex::new(RecorderDiagnostics::default()),
             last_event_at_ms: Mutex::new(None),
@@ -143,6 +154,34 @@ impl UsageRecorder {
             }
             *state = RecorderState::Idle;
         }
+    }
+
+    /// Clears durable usage and restarts an active measurement at the deletion boundary.
+    pub fn delete_history(&self, at: SystemTime) -> Result<(), String> {
+        let Some(store) = &self.history_store else {
+            return Err("usage history store unavailable".to_string());
+        };
+        let at_utc_ms = system_time_to_ms(at);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "usage recorder state mutex poisoned".to_string())?;
+
+        if let RecorderState::Recording(active) = &*state {
+            if at_utc_ms > active.started_at_utc_ms {
+                self.persist(active, at_utc_ms, "history_deleted");
+                *state = RecorderState::Recording(ActiveSession {
+                    subject: active.subject.clone(),
+                    started_at_utc_ms: at_utc_ms,
+                });
+            }
+        }
+
+        store.delete_all_usage_history().inspect_err(|error| {
+            if let Ok(mut diagnostics) = self.diagnostics.lock() {
+                diagnostics.persistence_error = Some(error.clone());
+            }
+        })
     }
 
     pub fn record_subscription_failure(&self, error: String) {
@@ -405,6 +444,26 @@ mod tests {
         let sessions = sink.sessions.lock().unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].end_reason, "measurement_stopped");
+    }
+
+    #[test]
+    fn deleting_history_restarts_an_active_session_at_the_deletion_boundary() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            UsageHistoryStore::with_storage_path(directory.path().join("usage.sqlite")).unwrap(),
+        );
+        let recorder = UsageRecorder::new(store.clone());
+        recorder.handle_event(foreground(1_000, r"C:\Apps\Editor.exe"));
+
+        recorder.delete_history(at(2_000)).unwrap();
+        recorder.checkpoint(at(3_000));
+
+        let (_, measured_date) = local_measurement_context(2_000);
+        let sessions = store.sessions_for_local_date(&measured_date).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].started_at_utc_ms, 2_000);
+        assert_eq!(sessions[0].ended_at_utc_ms, 3_000);
+        assert_eq!(sessions[0].end_reason, "checkpoint");
     }
 
     #[test]

--- a/src/infrastructure/tauri_adapter.rs
+++ b/src/infrastructure/tauri_adapter.rs
@@ -64,6 +64,12 @@ struct AutostartPayload {
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+struct CompleteOnboardingPayload {
+    enable_autostart: bool,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct UsageDatePayload<'a> {
     local_date: &'a str,
 }
@@ -110,6 +116,35 @@ pub async fn set_autostart_enabled(enabled: bool) -> AutostartStatus {
             autostart_status_from_fetch(enabled).await
         }
     }
+}
+
+pub async fn fetch_onboarding_completed() -> Result<bool, String> {
+    invoke_command("get_onboarding_completed")
+        .await
+        .map_err(|error| {
+            log_error(&format!("failed to fetch onboarding state: {error:?}"));
+            format!("failed to fetch onboarding state: {error:?}")
+        })
+}
+
+pub async fn complete_onboarding(enable_autostart: bool) -> Result<(), String> {
+    let payload = serde_wasm_bindgen::to_value(&CompleteOnboardingPayload { enable_autostart })
+        .map_err(|error| error.to_string())?;
+    invoke_command_with("complete_onboarding", payload)
+        .await
+        .map_err(|error| {
+            log_error(&format!("failed to complete onboarding: {error:?}"));
+            format!("failed to complete onboarding: {error:?}")
+        })
+}
+
+pub async fn delete_all_usage_history() -> Result<(), String> {
+    invoke_command("delete_all_usage_history")
+        .await
+        .map_err(|error| {
+            log_error(&format!("failed to delete usage history: {error:?}"));
+            format!("failed to delete usage history: {error:?}")
+        })
 }
 
 pub async fn load_daily_usage_summary(local_date: &str) -> Result<DailyUsageSummary, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod infrastructure;
 mod presentation;
 
 use leptos::prelude::*;
-use presentation::dashboard::Dashboard;
+use presentation::root::Root;
 use presentation::settings::Settings;
 use web_sys::window;
 
@@ -20,6 +20,6 @@ fn main() {
     if should_render_settings() {
         mount_to_body(|| view! { <Settings /> });
     } else {
-        mount_to_body(|| view! { <Dashboard /> });
+        mount_to_body(|| view! { <Root /> });
     }
 }

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -1,2 +1,4 @@
 pub mod dashboard;
+pub mod onboarding;
+pub mod root;
 pub mod settings;

--- a/src/presentation/onboarding.rs
+++ b/src/presentation/onboarding.rs
@@ -1,0 +1,103 @@
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+
+use crate::infrastructure::tauri_adapter::complete_onboarding;
+
+#[component]
+/// First-run setup requiring an explicit automatic-launch choice.
+pub fn Onboarding(on_complete: Callback<()>) -> impl IntoView {
+    let (autostart_choice, set_autostart_choice) = signal(None::<bool>);
+    let (submitting, set_submitting) = signal(false);
+    let (error_message, set_error_message) = signal(None::<String>);
+
+    view! {
+        <main class="onboarding-shell">
+            <section class="onboarding">
+                <header class="onboarding__header">
+                    <div class="onboarding__mark">"TW"</div>
+                    <span class="onboarding__eyebrow">"WELCOME TO TIME WISE"</span>
+                    <h1>"Understand where your time goes"</h1>
+                    <p>
+                        "Time Wise measures the application in focus and stores the history only on this computer. Window titles, URLs, and document names are never collected."
+                    </p>
+                </header>
+
+                <div class="onboarding__step">
+                    <div class="onboarding__step-number">"1"</div>
+                    <div>
+                        <h2>"Choose automatic launch"</h2>
+                        <p>
+                            "Time Wise measures usage while it is running in the system tray. Choose whether it should start when you sign in to Windows."
+                        </p>
+                    </div>
+                </div>
+
+                <div class="onboarding__choices" role="radiogroup" aria-label="Automatic launch preference">
+                    <button
+                        role="radio"
+                        aria-checked=move || (autostart_choice.get() == Some(true)).to_string()
+                        class:onboarding__choice=true
+                        class:onboarding__choice--selected=move || autostart_choice.get() == Some(true)
+                        disabled=move || submitting.get()
+                        on:click=move |_| set_autostart_choice.set(Some(true))
+                    >
+                        <span class="onboarding__choice-icon">"↗"</span>
+                        <span>
+                            <strong>"Start automatically"</strong>
+                            <small>"Recommended for complete daily history"</small>
+                        </span>
+                        <span class="onboarding__radio"></span>
+                    </button>
+                    <button
+                        role="radio"
+                        aria-checked=move || (autostart_choice.get() == Some(false)).to_string()
+                        class:onboarding__choice=true
+                        class:onboarding__choice--selected=move || autostart_choice.get() == Some(false)
+                        disabled=move || submitting.get()
+                        on:click=move |_| set_autostart_choice.set(Some(false))
+                    >
+                        <span class="onboarding__choice-icon">"○"</span>
+                        <span>
+                            <strong>"I'll start it myself"</strong>
+                            <small>"You can change this later in Settings"</small>
+                        </span>
+                        <span class="onboarding__radio"></span>
+                    </button>
+                </div>
+
+                <Show when=move || error_message.get().is_some()>
+                    <p class="onboarding__error" role="alert">
+                        {move || error_message.get().unwrap_or_default()}
+                    </p>
+                </Show>
+
+                <footer class="onboarding__footer">
+                    <span>"Your choice can be changed at any time."</span>
+                    <button
+                        class="onboarding__continue"
+                        disabled=move || autostart_choice.get().is_none() || submitting.get()
+                        on:click=move |_| {
+                            let Some(enable_autostart) = autostart_choice.get_untracked() else {
+                                return;
+                            };
+                            set_submitting.set(true);
+                            set_error_message.set(None);
+                            spawn_local(async move {
+                                match complete_onboarding(enable_autostart).await {
+                                    Ok(()) => on_complete.run(()),
+                                    Err(_) => {
+                                        set_error_message.set(Some(
+                                            "Setup could not be saved. Check the system settings and try again."
+                                                .to_string(),
+                                        ));
+                                        set_submitting.set(false);
+                                    }
+                                }
+                            });
+                        }
+                    >{move || if submitting.get() { "Saving…" } else { "Continue" }}</button>
+                </footer>
+            </section>
+        </main>
+    }
+}

--- a/src/presentation/root.rs
+++ b/src/presentation/root.rs
@@ -1,0 +1,58 @@
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+
+use crate::infrastructure::tauri_adapter::fetch_onboarding_completed;
+use crate::presentation::{dashboard::Dashboard, onboarding::Onboarding};
+
+#[component]
+/// Resolves first-run state before showing onboarding or the dashboard.
+pub fn Root() -> impl IntoView {
+    let (onboarding_completed, set_onboarding_completed) = signal(None::<bool>);
+    let (load_error, set_load_error) = signal(false);
+    let (retry, set_retry) = signal(0u64);
+
+    Effect::new(move |_| {
+        let _ = retry.get();
+        set_load_error.set(false);
+        spawn_local(async move {
+            match fetch_onboarding_completed().await {
+                Ok(completed) => set_onboarding_completed.set(Some(completed)),
+                Err(_) => {
+                    set_onboarding_completed.set(None);
+                    set_load_error.set(true);
+                }
+            }
+        });
+    });
+
+    view! {
+        {move || match onboarding_completed.get() {
+            Some(true) => view! { <Dashboard /> }.into_any(),
+            Some(false) => view! {
+                <Onboarding on_complete=Callback::new(move |()| {
+                    set_onboarding_completed.set(Some(true));
+                }) />
+            }.into_any(),
+            None if load_error.get() => view! {
+                <main class="onboarding-shell">
+                    <section class="onboarding-state" role="alert">
+                        <span class="onboarding-state__icon">"!"</span>
+                        <h1>"Setup unavailable"</h1>
+                        <p>"Time Wise couldn't load its local setup state."</p>
+                        <button on:click=move |_| {
+                            set_retry.update(|value| *value = value.wrapping_add(1));
+                        }>"Try again"</button>
+                    </section>
+                </main>
+            }.into_any(),
+            None => view! {
+                <main class="onboarding-shell">
+                    <section class="onboarding-state" aria-label="Loading setup">
+                        <span class="onboarding-state__spinner"></span>
+                        <p>"Preparing Time Wise…"</p>
+                    </section>
+                </main>
+            }.into_any(),
+        }}
+    }
+}

--- a/src/presentation/settings.rs
+++ b/src/presentation/settings.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsCast;
 use web_sys::HtmlInputElement;
 
 use crate::infrastructure::tauri_adapter::{
-    fetch_autostart_enabled, set_autostart_enabled, AutostartStatus,
+    delete_all_usage_history, fetch_autostart_enabled, set_autostart_enabled, AutostartStatus,
 };
 
 #[component]
@@ -13,7 +13,10 @@ pub fn Settings() -> impl IntoView {
     let (autostart_enabled, set_autostart_enabled_signal) = signal(false);
     let (loaded, set_loaded) = signal(false);
     let (status_message, set_status_message) = signal(None::<String>);
+    let (status_is_error, set_status_is_error) = signal(false);
     let (saving, set_saving) = signal(false);
+    let (show_delete_confirmation, set_show_delete_confirmation) = signal(false);
+    let (deleting, set_deleting) = signal(false);
 
     Effect::new(move |_| {
         if loaded.get() {
@@ -30,6 +33,7 @@ pub fn Settings() -> impl IntoView {
                         set_message.set(None);
                     }
                     Err(()) => {
+                        set_status_is_error.set(true);
                         set_message.set(Some(
                             "Unable to load automatic launch preference.".to_string(),
                         ));
@@ -46,71 +50,157 @@ pub fn Settings() -> impl IntoView {
                 <header class="settings__header">
                     <h1 class="settings__title">"Settings"</h1>
                     <p class="settings__subtitle">
-                        "Control how Time Wise behaves on startup."
+                        "Control startup behavior and locally stored usage data."
                     </p>
                 </header>
                 <div class="settings__content">
-                    <label class="settings__item">
-                        <input
-                            type="checkbox"
-                            class="settings__checkbox"
-                            prop:checked=move || autostart_enabled.get()
-                            on:change=move |ev| {
-                                let Some(target) = ev
-                                    .target()
-                                    .and_then(|value| value.dyn_into::<HtmlInputElement>().ok())
-                                else {
-                                    return;
-                                };
-                                let desired = target.checked();
-
-                                if saving.get() {
-                                    target.set_checked(autostart_enabled.get());
-                                    return;
-                                }
-
-                                set_status_message.set(None);
-                                set_autostart_enabled_signal.set(desired);
-                                set_saving.set(true);
-
-                                spawn_local({
-                                    let set_autostart = set_autostart_enabled_signal;
-                                    let set_message = set_status_message;
-                                    let set_saving = set_saving;
-                                    async move {
-                                        let AutostartStatus { enabled, success } =
-                                            set_autostart_enabled(desired).await;
-                                        set_autostart.set(enabled);
-                                        if success {
-                                            set_message.set(None);
-                                        } else {
-                                            set_message.set(Some(
-                                                "Could not update automatic launch preference."
-                                                    .to_string(),
-                                            ));
-                                        }
-                                        set_saving.set(false);
-                                    }
-                                });
-                            }
-                            disabled=move || !loaded.get() || saving.get()
-                        />
-                        <div class="settings__details">
-                            <span class="settings__label">"Launch on startup"</span>
-                            <span class="settings__description">
-                                "Start Time Wise automatically when your machine boots."
-                            </span>
+                    <section class="settings__group">
+                        <div class="settings__group-heading">
+                            <span class="settings__eyebrow">"GENERAL"</span>
+                            <h2>"Startup"</h2>
                         </div>
-                    </label>
+                        <label class="settings__item">
+                            <input
+                                type="checkbox"
+                                class="settings__checkbox"
+                                prop:checked=move || autostart_enabled.get()
+                                on:change=move |ev| {
+                                    let Some(target) = ev
+                                        .target()
+                                        .and_then(|value| value.dyn_into::<HtmlInputElement>().ok())
+                                    else {
+                                        return;
+                                    };
+                                    let desired = target.checked();
+
+                                    if saving.get() {
+                                        target.set_checked(autostart_enabled.get());
+                                        return;
+                                    }
+
+                                    set_status_message.set(None);
+                                    set_autostart_enabled_signal.set(desired);
+                                    set_saving.set(true);
+
+                                    spawn_local({
+                                        let set_autostart = set_autostart_enabled_signal;
+                                        let set_message = set_status_message;
+                                        let set_saving = set_saving;
+                                        async move {
+                                            let AutostartStatus { enabled, success } =
+                                                set_autostart_enabled(desired).await;
+                                            set_autostart.set(enabled);
+                                            if success {
+                                                set_message.set(None);
+                                            } else {
+                                                set_status_is_error.set(true);
+                                                set_message.set(Some(
+                                                    "Could not update automatic launch preference."
+                                                        .to_string(),
+                                                ));
+                                            }
+                                            set_saving.set(false);
+                                        }
+                                    });
+                                }
+                                disabled=move || !loaded.get() || saving.get()
+                            />
+                            <div class="settings__details">
+                                <span class="settings__label">"Launch on startup"</span>
+                                <span class="settings__description">
+                                    "Start Time Wise automatically when you sign in to Windows."
+                                </span>
+                            </div>
+                        </label>
+                    </section>
+
+                    <section class="settings__group settings__group--danger">
+                        <div class="settings__group-heading">
+                            <span class="settings__eyebrow">"DATA"</span>
+                            <h2>"Usage history"</h2>
+                        </div>
+                        <div class="settings__danger-item">
+                            <div class="settings__details">
+                                <span class="settings__label">"Delete all usage history"</span>
+                                <span class="settings__description">
+                                    "Permanently remove every recorded session and cached application icon from this computer."
+                                </span>
+                            </div>
+                            <button
+                                class="settings__delete-button"
+                                disabled=move || deleting.get()
+                                on:click=move |_| {
+                                    set_status_message.set(None);
+                                    set_show_delete_confirmation.set(true);
+                                }
+                            >"Delete…"</button>
+                        </div>
+                    </section>
+
                     <Show when=move || status_message.get().is_some()>
                         {move || {
                             status_message
                                 .get()
-                                .map(|message| view! { <p class="settings__status">{message}</p> })
+                                .map(|message| view! {
+                                    <p
+                                        class="settings__status"
+                                        class:settings__status--success=move || !status_is_error.get()
+                                    >{message}</p>
+                                })
                         }}
                     </Show>
                 </div>
             </section>
+
+            <Show when=move || show_delete_confirmation.get()>
+                <div class="settings-dialog-backdrop">
+                    <section
+                        class="settings-dialog"
+                        role="alertdialog"
+                        aria-modal="true"
+                        aria-labelledby="delete-history-title"
+                    >
+                        <div class="settings-dialog__icon">"!"</div>
+                        <h2 id="delete-history-title">"Delete all usage history?"</h2>
+                        <p>
+                            "This permanently deletes every measured session and application entry. This action cannot be undone. Your preferences will be kept."
+                        </p>
+                        <div class="settings-dialog__actions">
+                            <button
+                                class="settings-dialog__cancel"
+                                disabled=move || deleting.get()
+                                on:click=move |_| set_show_delete_confirmation.set(false)
+                            >"Cancel"</button>
+                            <button
+                                class="settings-dialog__confirm"
+                                disabled=move || deleting.get()
+                                on:click=move |_| {
+                                    set_deleting.set(true);
+                                    set_status_message.set(None);
+                                    spawn_local(async move {
+                                        match delete_all_usage_history().await {
+                                            Ok(()) => {
+                                                set_status_is_error.set(false);
+                                                set_status_message.set(Some(
+                                                    "All usage history was deleted.".to_string(),
+                                                ));
+                                                set_show_delete_confirmation.set(false);
+                                            }
+                                            Err(_) => {
+                                                set_status_is_error.set(true);
+                                                set_status_message.set(Some(
+                                                    "Could not delete usage history.".to_string(),
+                                                ));
+                                            }
+                                        }
+                                        set_deleting.set(false);
+                                    });
+                                }
+                            >{move || if deleting.get() { "Deleting…" } else { "Delete permanently" }}</button>
+                        </div>
+                    </section>
+                </div>
+            </Show>
         </main>
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -485,7 +485,277 @@ button {
   to { background-position: -200% 0; }
 }
 
+.onboarding-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 36px;
+  place-items: center;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(91, 119, 209, 0.15), transparent 28rem),
+    radial-gradient(circle at 90% 88%, rgba(119, 148, 98, 0.1), transparent 24rem),
+    #f3f6fb;
+}
+
+.onboarding {
+  width: min(100%, 720px);
+  padding: 38px 42px 32px;
+  border: 1px solid #dce2ec;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 70px rgba(37, 52, 82, 0.12);
+}
+
+.onboarding__header {
+  text-align: center;
+}
+
+.onboarding__mark {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 18px;
+  place-items: center;
+  border-radius: 14px;
+  color: #fff;
+  background: #526fc8;
+  box-shadow: 0 10px 22px rgba(65, 94, 181, 0.28);
+  font-size: 0.76rem;
+  font-weight: 780;
+  letter-spacing: 0.06em;
+}
+
+.onboarding__eyebrow,
+.settings__eyebrow {
+  color: #7c889d;
+  font-size: 0.67rem;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+}
+
+.onboarding__header h1 {
+  margin: 7px 0 10px;
+  color: #172135;
+  font-size: clamp(1.65rem, 4vw, 2.15rem);
+  letter-spacing: -0.045em;
+}
+
+.onboarding__header p {
+  max-width: 560px;
+  margin: 0 auto;
+  color: #69758a;
+  font-size: 0.85rem;
+  line-height: 1.65;
+}
+
+.onboarding__step {
+  display: flex;
+  margin: 30px 0 15px;
+  align-items: flex-start;
+  gap: 13px;
+}
+
+.onboarding__step-number {
+  display: grid;
+  width: 25px;
+  height: 25px;
+  flex: 0 0 25px;
+  place-items: center;
+  border-radius: 50%;
+  color: #4260bb;
+  background: #e9efff;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.onboarding__step h2 {
+  margin: 1px 0 4px;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.onboarding__step p {
+  margin: 0;
+  color: #788499;
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+
+.onboarding__choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 11px;
+}
+
+.onboarding__choice {
+  display: flex;
+  min-width: 0;
+  padding: 16px;
+  align-items: center;
+  gap: 11px;
+  border: 1px solid #dce2ec;
+  border-radius: 13px;
+  color: #263248;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.onboarding__choice:hover:not(:disabled) {
+  border-color: #aab9e4;
+}
+
+.onboarding__choice--selected {
+  border-color: #718bd6;
+  background: #f5f7ff;
+  box-shadow: inset 0 0 0 1px rgba(82, 111, 200, 0.2);
+}
+
+.onboarding__choice:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.onboarding__choice-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  place-items: center;
+  border-radius: 9px;
+  color: #526fc8;
+  background: #edf1fd;
+  font-weight: 750;
+}
+
+.onboarding__choice > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.onboarding__choice strong {
+  font-size: 0.78rem;
+}
+
+.onboarding__choice small {
+  color: #8994a7;
+  font-size: 0.65rem;
+  line-height: 1.35;
+}
+
+.onboarding__radio {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 15px;
+  border: 1.5px solid #bac3d1;
+  border-radius: 50%;
+}
+
+.onboarding__choice--selected .onboarding__radio {
+  border: 4px solid #5875cc;
+}
+
+.onboarding__error {
+  margin: 13px 0 0;
+  padding: 10px 12px;
+  border-radius: 9px;
+  color: #a4473d;
+  background: #fff0ee;
+  font-size: 0.72rem;
+}
+
+.onboarding__footer {
+  display: flex;
+  margin-top: 24px;
+  padding-top: 20px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-top: 1px solid #edf0f5;
+}
+
+.onboarding__footer > span {
+  color: #949eae;
+  font-size: 0.68rem;
+}
+
+.onboarding__continue,
+.onboarding-state button {
+  padding: 10px 21px;
+  border: 0;
+  border-radius: 10px;
+  color: #fff;
+  background: #526fc8;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 680;
+  box-shadow: 0 8px 18px rgba(65, 94, 181, 0.2);
+}
+
+.onboarding__continue:disabled {
+  cursor: default;
+  opacity: 0.42;
+  box-shadow: none;
+}
+
+.onboarding-state {
+  display: flex;
+  width: min(100%, 390px);
+  padding: 34px;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid #dce2ec;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 18px 50px rgba(37, 52, 82, 0.1);
+  text-align: center;
+}
+
+.onboarding-state h1,
+.onboarding-state p {
+  margin: 0;
+}
+
+.onboarding-state h1 {
+  font-size: 1.1rem;
+}
+
+.onboarding-state p {
+  color: #788499;
+  font-size: 0.78rem;
+}
+
+.onboarding-state__icon,
+.onboarding-state__spinner {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 50%;
+}
+
+.onboarding-state__icon {
+  color: #a4473d;
+  background: #f9dedb;
+  font-weight: 750;
+}
+
+.onboarding-state__spinner {
+  border: 3px solid #dce3f4;
+  border-top-color: #526fc8;
+  animation: onboarding-spin 0.8s linear infinite;
+}
+
+@keyframes onboarding-spin {
+  to { transform: rotate(360deg); }
+}
+
 .settings-app {
+  position: relative;
   min-height: 100vh;
   padding: 32px;
 }
@@ -524,7 +794,19 @@ button {
 }
 
 .settings__content {
-  gap: 14px;
+  gap: 19px;
+}
+
+.settings__group {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.settings__group-heading h2 {
+  margin: 3px 0 0;
+  font-size: 0.98rem;
+  font-weight: 680;
 }
 
 .settings__item {
@@ -535,6 +817,20 @@ button {
   border: 1px solid #d8dfeb;
   border-radius: 14px;
   background: #fff;
+}
+
+.settings__danger-item {
+  display: flex;
+  padding: 18px 20px;
+  align-items: center;
+  gap: 18px;
+  border: 1px solid #ead3d0;
+  border-radius: 14px;
+  background: #fffafa;
+}
+
+.settings__danger-item .settings__details {
+  flex: 1;
 }
 
 .settings__checkbox {
@@ -553,11 +849,123 @@ button {
 
 .settings__status {
   margin: 0;
+  padding: 10px 12px;
+  border-radius: 9px;
   color: #a4463d;
+  background: #fff0ee;
   font-size: 0.8rem;
 }
 
+.settings__status--success {
+  color: #4c7135;
+  background: #f0f7eb;
+}
+
+.settings__delete-button {
+  flex: 0 0 auto;
+  padding: 8px 13px;
+  border: 1px solid #d78f88;
+  border-radius: 9px;
+  color: #a34239;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.settings__delete-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.settings-dialog-backdrop {
+  position: fixed;
+  z-index: 20;
+  inset: 0;
+  display: grid;
+  padding: 20px;
+  place-items: center;
+  background: rgba(24, 33, 47, 0.42);
+  backdrop-filter: blur(3px);
+}
+
+.settings-dialog {
+  width: min(100%, 410px);
+  padding: 26px;
+  border: 1px solid #e5c9c5;
+  border-radius: 17px;
+  background: #fff;
+  box-shadow: 0 24px 70px rgba(37, 42, 58, 0.22);
+}
+
+.settings-dialog__icon {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 50%;
+  color: #a4473d;
+  background: #f8dedb;
+  font-weight: 780;
+}
+
+.settings-dialog h2 {
+  margin: 15px 0 7px;
+  font-size: 1.05rem;
+}
+
+.settings-dialog p {
+  margin: 0;
+  color: #707d91;
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.settings-dialog__actions {
+  display: flex;
+  margin-top: 22px;
+  justify-content: flex-end;
+  gap: 9px;
+}
+
+.settings-dialog__actions button {
+  padding: 9px 13px;
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 660;
+}
+
+.settings-dialog__cancel {
+  border: 1px solid #d9dfe8;
+  color: #536076;
+  background: #fff;
+}
+
+.settings-dialog__confirm {
+  border: 1px solid #a9453c;
+  color: #fff;
+  background: #b64d43;
+}
+
+.settings-dialog__actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 @media (max-width: 720px) {
+  .onboarding-shell {
+    padding: 22px;
+  }
+
+  .onboarding {
+    padding: 30px 25px 25px;
+  }
+
+  .onboarding__choices {
+    grid-template-columns: 1fr;
+  }
+
   .dashboard {
     padding: 25px 20px 34px;
   }
@@ -576,6 +984,34 @@ button {
 }
 
 @media (max-width: 460px) {
+  .onboarding-shell {
+    padding: 12px;
+    place-items: start center;
+  }
+
+  .onboarding {
+    padding: 25px 18px 20px;
+    border-radius: 17px;
+  }
+
+  .onboarding__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .onboarding__footer > span {
+    text-align: center;
+  }
+
+  .settings-app {
+    padding: 22px 16px;
+  }
+
+  .settings__danger-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .dashboard {
     padding: 21px 14px 28px;
   }


### PR DESCRIPTION
## Summary

- add a first-run onboarding flow that explains local application-usage measurement
- require an explicit automatic-launch choice before setup can finish
- persist onboarding completion and the selected autostart preference in SQLite
- show the main window automatically until onboarding is complete
- keep autostart configurable from the existing Settings window
- add an irreversible-confirmation dialog for deleting all usage history
- remove recorded sessions and cached application metadata while preserving preferences
- restart an active measurement at the deletion boundary so deleted time does not reappear or overlap
- enlarge the Settings window for the additional data controls

## Impact

New installations are guided through the privacy and startup choice before reaching the dashboard. Existing installations without the onboarding setting will see the setup once after updating.

Deleting history now clears all measured sessions and application metadata. Preferences remain intact, and a currently measured application starts a fresh session at the deletion timestamp.

## Validation

With `cargo tauri dev` kept running for hot reload:

- `cargo +1.95.0 fmt --all`
- `cargo +1.95.0 clippy --workspace --bins --tests --examples -- -D rust_2018_idioms -D warnings`
- `cargo +1.95.0 test -p time-wise-ui` (13 passed)
- `cargo +1.95.0 test -p time-wise --lib` (34 passed)
- Tauri frontend and backend hot reload completed successfully
- `git diff --check`

The full local workspace test cannot replace the running Windows executable while `tauri dev` holds it open; GitHub CI runs the unlocked full suite.

## Manual verification

- [ ] Confirm onboarding layout and both autostart choices on Windows 11
- [ ] Confirm setup completion survives restart
- [ ] Confirm the Settings autostart toggle updates Windows startup registration
- [ ] Confirm the deletion warning and post-delete dashboard state
- [ ] Add a Windows screenshot or GIF to this PR

Automated visual capture is unavailable because the browser bridge cannot resolve the WSL workspace URI.

Closes #108