### PR TITLE
feat: add macOS usage tracking

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,10 @@ windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false, features = ["libc", "NSRunningApplication", "NSWorkspace"] }
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/app_identity.rs
+++ b/src-tauri/src/app_identity.rs
@@ -1,4 +1,4 @@
-//! Resolves observed Windows processes to product-level application identities.
+//! Resolves observed desktop processes to product-level application identities.
 
 use std::path::Path;
 
@@ -18,8 +18,11 @@ pub fn resolve(process: &ProcessIdentity) -> AppMetadata {
         .map(str::to_owned)
         .unwrap_or_else(|| executable_display_name(&process.executable));
 
-    let stable_key = if let Some(package_family) = non_empty(process.package_family_name.as_deref())
+    let stable_key = if let Some(bundle_identifier) =
+        non_empty(process.bundle_identifier.as_deref())
     {
+        format!("macos-bundle:{}", normalize_key_part(bundle_identifier))
+    } else if let Some(package_family) = non_empty(process.package_family_name.as_deref()) {
         format!("windows-package:{}", normalize_key_part(package_family))
     } else if let Some(product_name) = non_empty(process.product_name.as_deref()) {
         let publisher = non_empty(process.company_name.as_deref()).unwrap_or("unknown-publisher");
@@ -36,8 +39,8 @@ pub fn resolve(process: &ProcessIdentity) -> AppMetadata {
         stable_key,
         display_name,
         executable: Some(executable.clone()),
-        // The dashboard can ask Windows Shell for the representative icon from
-        // this source without persisting a window title or other user content.
+        // Platform adapters can use the executable as an icon source without
+        // persisting a window title or other user content.
         icon_source: Some(executable),
         icon_png: process.icon_png.clone(),
     }
@@ -80,7 +83,12 @@ fn normalize_key_part(value: &str) -> String {
 }
 
 fn normalize_path(value: &str) -> String {
-    value.trim().replace('/', "\\").to_lowercase()
+    let value = value.trim();
+    if value.contains('\\') || value.to_ascii_lowercase().ends_with(".exe") {
+        value.replace('/', "\\").to_lowercase()
+    } else {
+        value.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -139,5 +147,23 @@ mod tests {
             resolve(&upper).icon_source.as_deref(),
             Some(r"C:\Apps\Terminal.exe")
         );
+    }
+
+    #[test]
+    fn macos_bundle_identifier_groups_bundle_executables() {
+        let mut editor = process("/Applications/Editor.app/Contents/MacOS/Editor");
+        editor.bundle_identifier = Some("com.example.Editor".into());
+        editor.product_name = Some("Editor".into());
+
+        let mut helper = process("/Applications/Editor.app/Contents/Frameworks/Helper");
+        helper.bundle_identifier = editor.bundle_identifier.clone();
+        helper.product_name = editor.product_name.clone();
+
+        assert_eq!(
+            resolve(&editor).stable_key,
+            "macos-bundle:com.example.editor"
+        );
+        assert_eq!(resolve(&editor).stable_key, resolve(&helper).stable_key);
+        assert_eq!(resolve(&editor).display_name, "Editor");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -285,7 +285,7 @@ pub fn run() {
                         }
                         Err(err) => {
                             recorder.record_subscription_failure(err.clone());
-                            eprintln!("failed to start Windows event probe: {err}");
+                            eprintln!("failed to start desktop event probe: {err}");
                         }
                     }
 

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use objc2::rc::autoreleasepool;
+use objc2_app_kit::NSWorkspace;
+
+use super::{DesktopEvent, ObservationFailure, ProcessIdentity};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug)]
+pub struct EventProbe {
+    stopped: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for EventProbe {
+    fn drop(&mut self) {
+        self.stopped.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+pub fn start_event_probe() -> Result<(EventProbe, mpsc::Receiver<DesktopEvent>), String> {
+    let (sender, receiver) = mpsc::channel();
+    let stopped = Arc::new(AtomicBool::new(false));
+    let thread_stopped = stopped.clone();
+    let thread = thread::Builder::new()
+        .name("macos-foreground-probe".to_string())
+        .spawn(move || {
+            let mut last_process_id = None;
+            while !thread_stopped.load(Ordering::Acquire) {
+                let event = autoreleasepool(|_| observe_frontmost_application());
+                let process_id = event.process.as_ref().map(|process| process.process_id);
+                if process_id != last_process_id {
+                    last_process_id = process_id;
+                    if sender.send(event).is_err() {
+                        break;
+                    }
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+        })
+        .map_err(|err| format!("failed to spawn macOS observer thread: {err}"))?;
+
+    Ok((
+        EventProbe {
+            stopped,
+            thread: Some(thread),
+        },
+        receiver,
+    ))
+}
+
+fn observe_frontmost_application() -> DesktopEvent {
+    // SAFETY: These AppKit accessors return retained immutable objects. Each call
+    // is made inside an autorelease pool owned by the observer thread.
+    let application = unsafe { NSWorkspace::sharedWorkspace().frontmostApplication() };
+    let Some(application) = application else {
+        return DesktopEvent::foreground(
+            None,
+            Some(ObservationFailure::ForegroundWindowUnavailable),
+        );
+    };
+
+    // SAFETY: NSRunningApplication properties are immutable snapshots for the
+    // running process and are copied into Rust-owned values before returning.
+    let process_id = unsafe { application.processIdentifier() };
+    if process_id <= 0 {
+        return DesktopEvent::foreground(None, Some(ObservationFailure::ProcessIdUnavailable));
+    }
+    let executable = unsafe {
+        application
+            .executableURL()
+            .and_then(|url| url.path())
+            .map(|path| PathBuf::from(path.to_string()))
+    };
+    let Some(executable) = executable else {
+        return DesktopEvent::foreground(
+            None,
+            Some(ObservationFailure::ExecutablePathUnavailable(
+                process_id as u32,
+            )),
+        );
+    };
+    let product_name = unsafe { application.localizedName().map(|name| name.to_string()) };
+    let bundle_identifier = unsafe {
+        application
+            .bundleIdentifier()
+            .map(|identifier| identifier.to_string())
+    };
+
+    DesktopEvent::foreground(
+        Some(ProcessIdentity {
+            process_id: process_id as u32,
+            executable,
+            bundle_identifier,
+            product_name,
+            ..ProcessIdentity::default()
+        }),
+        None,
+    )
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -3,12 +3,16 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 mod noop;
 #[cfg(target_os = "windows")]
 mod windows;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+pub use macos::start_event_probe;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub use noop::start_event_probe;
 #[cfg(target_os = "windows")]
 pub use windows::start_event_probe;
@@ -28,6 +32,7 @@ pub struct ProcessIdentity {
     pub executable: PathBuf,
     pub package_family_name: Option<String>,
     pub application_user_model_id: Option<String>,
+    pub bundle_identifier: Option<String>,
     pub product_name: Option<String>,
     pub company_name: Option<String>,
     pub icon_png: Option<Vec<u8>>,

--- a/src/presentation/dashboard.rs
+++ b/src/presentation/dashboard.rs
@@ -1,4 +1,4 @@
-//! Leptos components for the Windows v1 usage dashboard.
+//! Leptos components for the desktop usage dashboard.
 
 use leptos::prelude::*;
 use leptos::task::spawn_local;

--- a/src/presentation/onboarding.rs
+++ b/src/presentation/onboarding.rs
@@ -27,7 +27,7 @@ pub fn Onboarding(on_complete: Callback<()>) -> impl IntoView {
                     <div>
                         <h2>"Choose automatic launch"</h2>
                         <p>
-                            "Time Wise measures usage while it is running in the system tray. Choose whether it should start when you sign in to Windows."
+                            "Time Wise measures usage while it is running in the system tray. Choose whether it should start when you sign in to your computer."
                         </p>
                     </div>
                 </div>

--- a/src/presentation/settings.rs
+++ b/src/presentation/settings.rs
@@ -108,7 +108,7 @@ pub fn Settings() -> impl IntoView {
                             <div class="settings__details">
                                 <span class="settings__label">"Launch on startup"</span>
                                 <span class="settings__description">
-                                    "Start Time Wise automatically when you sign in to Windows."
+                                    "Start Time Wise automatically when you sign in to your computer."
                                 </span>
                             </div>
                         </label>


### PR DESCRIPTION
## Summary

- add a macOS foreground-application probe backed by AppKit
- identify macOS applications by bundle identifier and preserve display metadata
- make onboarding, settings, diagnostics, and dashboard wording platform-neutral

## Why

The usage-session recorder previously received desktop focus events only on Windows. On macOS the platform adapter was a no-op, so focused application sessions were not persisted.

## Impact

Time Wise now records foreground application changes on macOS while preserving the existing Windows implementation and the fallback behavior for other platforms.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- pre-commit and pre-push hooks
