### PR TITLE
chore: update application identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Time Wise",
   "version": "0.1.0",
-  "identifier": "com.9renpoto.time-wise",
+  "identifier": "io.github.umeno3.time-wise",
   "build": {
     "beforeDevCommand": "trunk serve",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tests/config.rs
+++ b/src-tauri/tests/config.rs
@@ -40,6 +40,7 @@ fn tauri_window_defaults_and_build_commands() {
 
     // product identity
     assert_eq!(v["productName"], "Time Wise");
+    assert_eq!(v["identifier"], "io.github.umeno3.time-wise");
 
     // build commands
     assert_eq!(v["build"]["beforeDevCommand"], "trunk serve");


### PR DESCRIPTION
## Summary

- align the Tauri application identifier with the transferred GitHub namespace
- add a configuration regression test for the new identifier

## Why

The repository has moved to `umeno3/time-wise`, so the application identifier should no longer claim the previous `com.9renpoto` namespace. Using `io.github.umeno3.time-wise` keeps the identifier tied to a namespace controlled by the current repository owner and prepares the app for cross-platform distribution.

## Impact

The application identity changes from `com.9renpoto.time-wise` to `io.github.umeno3.time-wise`. No migration is included because the application has not yet had a public release.

## Validation

- `node .github/scripts/set-version.mjs --check`
- `cargo fmt --all -- --check`
- `cargo test -p time-wise --test config`
- pre-commit and pre-push hooks (typos, Biome, Rust formatting, Tauri clippy, and Tauri tests)

A full local Tauri build could not be completed because the `wasm32-unknown-unknown` target is not installed in the current environment.
