### PR TITLE
feat: surface measurement health diagnostics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use tauri::{
 };
 use usage_history::UsageHistoryStore;
 use usage_queries::{fetch_daily_usage_summary, fetch_weekly_usage_summary};
-use usage_recorder::{UsageRecorder, CHECKPOINT_INTERVAL_SECONDS};
+use usage_recorder::{MeasurementHealth, UsageRecorder, CHECKPOINT_INTERVAL_SECONDS};
 
 #[cfg(not(target_os = "macos"))]
 use tauri::{PhysicalPosition, Position};
@@ -184,6 +184,11 @@ fn delete_all_usage_history(recorder: State<'_, Arc<UsageRecorder>>) -> Result<(
     recorder.delete_history(SystemTime::now())
 }
 
+#[tauri::command]
+fn fetch_measurement_health(recorder: State<'_, Arc<UsageRecorder>>) -> MeasurementHealth {
+    recorder.health()
+}
+
 fn update_autostart(autostart: &AutoLaunchManager, enabled: bool) -> Result<bool, String> {
     let result = if enabled {
         autostart.enable()
@@ -219,6 +224,7 @@ pub fn run() {
             delete_all_usage_history,
             fetch_app_usage_records,
             fetch_daily_usage_summary,
+            fetch_measurement_health,
             fetch_startup_records,
             fetch_weekly_usage_summary,
             get_autostart_enabled,
@@ -280,6 +286,7 @@ pub fn run() {
                                 while let Ok(event) = event_receiver.recv() {
                                     event_recorder.handle_event(event);
                                 }
+                                event_recorder.record_subscription_ended();
                             });
                             app.manage(probe);
                         }

--- a/src-tauri/src/usage_recorder.rs
+++ b/src-tauri/src/usage_recorder.rs
@@ -1,5 +1,6 @@
 //! Converts desktop lifecycle events into durable usage sessions.
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -12,6 +13,7 @@ use crate::platform::{DesktopEvent, DesktopEventKind, ObservationFailure};
 use crate::usage_history::{AppMetadata, NewUsageSession, UsageHistoryStore, UsageSubject};
 
 pub const CHECKPOINT_INTERVAL_SECONDS: u64 = 30;
+const MAX_DIAGNOSTIC_EVENTS: usize = 50;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TrackedSubject {
@@ -37,6 +39,29 @@ pub struct RecorderDiagnostics {
     pub subscription_error: Option<String>,
     pub observation_failure: Option<ObservationFailure>,
     pub persistence_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeasurementHealthStatus {
+    Healthy,
+    EventSubscriptionFailed,
+    ObservationDegraded,
+    PersistenceFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticEvent {
+    pub occurred_at_utc_ms: u64,
+    pub code: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasurementHealth {
+    pub status: MeasurementHealthStatus,
+    pub latest_diagnostic: Option<DiagnosticEvent>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,6 +106,7 @@ pub struct UsageRecorder {
     history_store: Option<Arc<UsageHistoryStore>>,
     state: Mutex<RecorderState>,
     diagnostics: Mutex<RecorderDiagnostics>,
+    diagnostic_events: Mutex<VecDeque<DiagnosticEvent>>,
     last_event_at_ms: Mutex<Option<u64>>,
 }
 
@@ -94,6 +120,7 @@ impl UsageRecorder {
             history_store: Some(store),
             state: Mutex::new(RecorderState::Idle),
             diagnostics: Mutex::new(RecorderDiagnostics::default()),
+            diagnostic_events: Mutex::new(VecDeque::new()),
             last_event_at_ms: Mutex::new(None),
         }
     }
@@ -105,6 +132,7 @@ impl UsageRecorder {
             history_store: None,
             state: Mutex::new(RecorderState::Idle),
             diagnostics: Mutex::new(RecorderDiagnostics::default()),
+            diagnostic_events: Mutex::new(VecDeque::new()),
             last_event_at_ms: Mutex::new(None),
         }
     }
@@ -113,6 +141,9 @@ impl UsageRecorder {
         let observed_at_utc_ms = system_time_to_ms(event.observed_at);
         if !self.accept_event_timestamp(observed_at_utc_ms) {
             return;
+        }
+        if let Ok(mut diagnostics) = self.diagnostics.lock() {
+            diagnostics.subscription_error = None;
         }
         match event.kind {
             DesktopEventKind::ForegroundChanged => {
@@ -188,6 +219,11 @@ impl UsageRecorder {
         if let Ok(mut diagnostics) = self.diagnostics.lock() {
             diagnostics.subscription_error = Some(error);
         }
+        self.record_diagnostic("event_subscription_failed");
+    }
+
+    pub fn record_subscription_ended(&self) {
+        self.record_subscription_failure("desktop event subscription ended".to_string());
     }
 
     #[must_use]
@@ -199,6 +235,29 @@ impl UsageRecorder {
                 persistence_error: Some("usage recorder diagnostics mutex poisoned".into()),
                 ..RecorderDiagnostics::default()
             })
+    }
+
+    #[must_use]
+    pub fn health(&self) -> MeasurementHealth {
+        let diagnostics = self.diagnostics();
+        let status = if diagnostics.persistence_error.is_some() {
+            MeasurementHealthStatus::PersistenceFailed
+        } else if diagnostics.subscription_error.is_some() {
+            MeasurementHealthStatus::EventSubscriptionFailed
+        } else if diagnostics.observation_failure.is_some() {
+            MeasurementHealthStatus::ObservationDegraded
+        } else {
+            MeasurementHealthStatus::Healthy
+        };
+        let latest_diagnostic = self
+            .diagnostic_events
+            .lock()
+            .ok()
+            .and_then(|events| events.back().cloned());
+        MeasurementHealth {
+            status,
+            latest_diagnostic,
+        }
     }
 
     fn focus_changed(&self, subject: TrackedSubject, at_utc_ms: u64) {
@@ -275,19 +334,42 @@ impl UsageRecorder {
             measured_local_date,
             end_reason: reason,
         });
-        if let Err(error) = result {
-            if let Ok(mut diagnostics) = self.diagnostics.lock() {
-                diagnostics.persistence_error = Some(error);
+        if let Ok(mut diagnostics) = self.diagnostics.lock() {
+            match result {
+                Ok(()) => diagnostics.persistence_error = None,
+                Err(error) => {
+                    diagnostics.persistence_error = Some(error);
+                    drop(diagnostics);
+                    self.record_diagnostic("usage_history_write_failed");
+                }
             }
         }
     }
 
     fn record_observation_failure(&self, failure: Option<ObservationFailure>) {
-        if let Some(failure) = failure {
-            if let Ok(mut diagnostics) = self.diagnostics.lock() {
-                diagnostics.observation_failure = Some(failure);
+        if let Ok(mut diagnostics) = self.diagnostics.lock() {
+            match failure {
+                Some(failure) => {
+                    diagnostics.observation_failure = Some(failure);
+                    drop(diagnostics);
+                    self.record_diagnostic("foreground_observation_failed");
+                }
+                None => diagnostics.observation_failure = None,
             }
         }
+    }
+
+    fn record_diagnostic(&self, code: &'static str) {
+        let Ok(mut events) = self.diagnostic_events.lock() else {
+            return;
+        };
+        if events.len() == MAX_DIAGNOSTIC_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(DiagnosticEvent {
+            occurred_at_utc_ms: system_time_to_ms(SystemTime::now()),
+            code,
+        });
     }
 
     fn accept_event_timestamp(&self, at_utc_ms: u64) -> bool {
@@ -325,6 +407,7 @@ fn system_time_to_ms(time: SystemTime) -> u64 {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[derive(Default)]
     struct MemorySink {
@@ -335,6 +418,21 @@ mod tests {
         fn save(&self, session: &SessionRecord) -> Result<(), String> {
             self.sessions.lock().unwrap().push(session.clone());
             Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecoveringSink {
+        fail_next: AtomicBool,
+    }
+
+    impl SessionSink for RecoveringSink {
+        fn save(&self, _session: &SessionRecord) -> Result<(), String> {
+            if self.fail_next.swap(false, Ordering::SeqCst) {
+                Err("database write failed for Secret Document.txt".to_string())
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -477,14 +575,47 @@ mod tests {
             failure: Some(ObservationFailure::ProcessOpenFailed(5)),
         });
         let diagnostics = recorder.diagnostics();
-        assert_eq!(
-            diagnostics.subscription_error.as_deref(),
-            Some("hook failed")
-        );
+        assert_eq!(diagnostics.subscription_error, None);
         assert_eq!(
             diagnostics.observation_failure,
             Some(ObservationFailure::ProcessOpenFailed(5))
         );
+        assert_eq!(
+            recorder.health().status,
+            MeasurementHealthStatus::ObservationDegraded
+        );
+
+        recorder.handle_event(foreground(20, r"C:\Apps\Editor.exe"));
+        assert_eq!(recorder.health().status, MeasurementHealthStatus::Healthy);
+    }
+
+    #[test]
+    fn persistence_health_recovers_after_a_successful_checkpoint() {
+        let sink = Arc::new(RecoveringSink::default());
+        sink.fail_next.store(true, Ordering::SeqCst);
+        let recorder = UsageRecorder::with_sink(sink);
+        recorder.handle_event(foreground(1_000, r"C:\Apps\Editor.exe"));
+        recorder.checkpoint(at(2_000));
+        assert_eq!(
+            recorder.health().status,
+            MeasurementHealthStatus::PersistenceFailed
+        );
+
+        recorder.checkpoint(at(3_000));
+        assert_eq!(recorder.health().status, MeasurementHealthStatus::Healthy);
+    }
+
+    #[test]
+    fn public_diagnostics_never_include_private_error_details() {
+        let (_sink, recorder) = recorder();
+        recorder.record_subscription_failure(
+            "window title: Secret Document; https://private.example".to_string(),
+        );
+
+        let serialized = serde_json::to_string(&recorder.health()).unwrap();
+        assert!(serialized.contains("event_subscription_failed"));
+        assert!(!serialized.contains("Secret Document"));
+        assert!(!serialized.contains("private.example"));
     }
 
     #[test]

--- a/src/infrastructure/tauri_adapter.rs
+++ b/src/infrastructure/tauri_adapter.rs
@@ -5,6 +5,29 @@ use web_sys::{console, window};
 
 use crate::domain::usage_summary::{DailyUsageSummary, WeeklyUsageSummary};
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeasurementHealthStatus {
+    Healthy,
+    EventSubscriptionFailed,
+    ObservationDegraded,
+    PersistenceFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticEvent {
+    pub occurred_at_utc_ms: u64,
+    pub code: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasurementHealth {
+    pub status: MeasurementHealthStatus,
+    pub latest_diagnostic: Option<DiagnosticEvent>,
+}
+
 async fn invoke_command_with<T>(command: &str, payload: JsValue) -> Result<T, JsValue>
 where
     T: serde::de::DeserializeOwned,
@@ -166,6 +189,15 @@ pub async fn load_weekly_usage_summary(local_date: &str) -> Result<WeeklyUsageSu
         .map_err(|error| {
             log_error(&format!("failed to fetch weekly usage summary: {error:?}"));
             format!("failed to fetch weekly usage summary: {error:?}")
+        })
+}
+
+pub async fn fetch_measurement_health() -> Result<MeasurementHealth, String> {
+    invoke_command("fetch_measurement_health")
+        .await
+        .map_err(|error| {
+            log_error(&format!("failed to fetch measurement health: {error:?}"));
+            format!("failed to fetch measurement health: {error:?}")
         })
 }
 

--- a/src/presentation/dashboard.rs
+++ b/src/presentation/dashboard.rs
@@ -11,7 +11,10 @@ use crate::application::usage_dashboard::{
     shift_local_date, usage_bar_height,
 };
 use crate::domain::usage_summary::{AppUsageTotal, DailyUsageSummary, WeeklyUsageSummary};
-use crate::infrastructure::tauri_adapter::{load_daily_usage_summary, load_weekly_usage_summary};
+use crate::infrastructure::tauri_adapter::{
+    fetch_measurement_health, load_daily_usage_summary, load_weekly_usage_summary,
+    MeasurementHealth, MeasurementHealthStatus,
+};
 
 const USAGE_REFRESH_MILLIS: i32 = 30_000;
 const WEEKDAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -117,6 +120,7 @@ pub fn Dashboard() -> impl IntoView {
     let (usage_data, set_usage_data) = signal(None::<UsageData>);
     let (loading, set_loading) = signal(true);
     let (load_error, set_load_error) = signal(None::<String>);
+    let (measurement_health, set_measurement_health) = signal(None::<MeasurementHealth>);
     let (refresh_tick, set_refresh_tick) = signal(0u64);
     let request_id = StoredValue::new(0u64);
 
@@ -141,6 +145,13 @@ pub fn Dashboard() -> impl IntoView {
         set_load_error.set(None);
 
         spawn_local(async move {
+            match fetch_measurement_health().await {
+                Ok(health) => set_measurement_health.set(Some(health)),
+                Err(_) => set_measurement_health.set(Some(MeasurementHealth {
+                    status: MeasurementHealthStatus::EventSubscriptionFailed,
+                    latest_diagnostic: None,
+                })),
+            }
             let result = match selected_period {
                 UsagePeriod::Day => load_daily_usage_summary(&date).await.map(UsageData::Daily),
                 UsagePeriod::Week => load_weekly_usage_summary(&date)
@@ -251,6 +262,26 @@ pub fn Dashboard() -> impl IntoView {
                     }
                 >"›"</button>
             </nav>
+
+            <Show when=move || measurement_health.get().is_some_and(|health| health.status != MeasurementHealthStatus::Healthy)>
+                <section class="dashboard__state dashboard__state--warning" role="status">
+                    <span class="dashboard__state-icon">"!"</span>
+                    <div>
+                        <strong>{move || measurement_health.get().map(|health| match health.status {
+                            MeasurementHealthStatus::Healthy => "Measurement active",
+                            MeasurementHealthStatus::EventSubscriptionFailed => "Measurement unavailable",
+                            MeasurementHealthStatus::ObservationDegraded => "Some activity is unclassified",
+                            MeasurementHealthStatus::PersistenceFailed => "Activity could not be saved",
+                        }).unwrap_or("Measurement unavailable")}</strong>
+                        <p>{move || measurement_health.get().map(|health| match health.status {
+                            MeasurementHealthStatus::Healthy => "Time Wise is recording activity.",
+                            MeasurementHealthStatus::EventSubscriptionFailed => "Time Wise lost access to desktop activity events. Restart the app to retry.",
+                            MeasurementHealthStatus::ObservationDegraded => "Time Wise could not identify the focused application. The time is kept as unclassified activity.",
+                            MeasurementHealthStatus::PersistenceFailed => "Time Wise will retry saving when the next activity checkpoint is recorded.",
+                        }).unwrap_or("Time Wise could not determine the current measurement state.")}</p>
+                    </div>
+                </section>
+            </Show>
 
             <Show when=move || load_error.get().is_some()>
                 <section class="dashboard__state dashboard__state--error" role="alert">

--- a/styles.css
+++ b/styles.css
@@ -2,8 +2,8 @@
   color: #18212f;
   background: #f3f6fb;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
   font-synthesis: none;
 }
 
@@ -16,7 +16,11 @@ body {
   min-height: 100vh;
   margin: 0;
   background:
-    radial-gradient(circle at 85% 0%, rgba(104, 132, 255, 0.12), transparent 34rem),
+    radial-gradient(
+      circle at 85% 0%,
+      rgba(104, 132, 255, 0.12),
+      transparent 34rem
+    ),
     #f3f6fb;
 }
 
@@ -416,6 +420,12 @@ button {
   background: #fff9f8;
 }
 
+.dashboard__state--warning {
+  margin: 16px 0;
+  border: 1px solid #ead6a1;
+  background: #fffaf0;
+}
+
 .dashboard__state--empty {
   margin: 4px 0 10px;
   border: 0;
@@ -433,6 +443,11 @@ button {
   color: #65738a;
   background: #e9edf3;
   font-weight: 750;
+}
+
+.dashboard__state--warning .dashboard__state-icon {
+  color: #8b671c;
+  background: #f6e8bd;
 }
 
 .dashboard__state--error .dashboard__state-icon {
@@ -481,8 +496,12 @@ button {
 }
 
 @keyframes dashboard-shimmer {
-  from { background-position: 200% 0; }
-  to { background-position: -200% 0; }
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
 }
 
 .onboarding-shell {
@@ -491,8 +510,16 @@ button {
   padding: 36px;
   place-items: center;
   background:
-    radial-gradient(circle at 18% 8%, rgba(91, 119, 209, 0.15), transparent 28rem),
-    radial-gradient(circle at 90% 88%, rgba(119, 148, 98, 0.1), transparent 24rem),
+    radial-gradient(
+      circle at 18% 8%,
+      rgba(91, 119, 209, 0.15),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 90% 88%,
+      rgba(119, 148, 98, 0.1),
+      transparent 24rem
+    ),
     #f3f6fb;
 }
 
@@ -598,7 +625,10 @@ button {
   background: #fff;
   cursor: pointer;
   text-align: left;
-  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .onboarding__choice:hover:not(:disabled) {
@@ -751,7 +781,9 @@ button {
 }
 
 @keyframes onboarding-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .settings-app {


### PR DESCRIPTION
## Summary

- monitor desktop event subscription, foreground observation, and SQLite persistence health
- expose privacy-safe diagnostic codes and timestamps through a Tauri command
- show measurement warnings in the dashboard and clear recoverable failures after successful events or writes
- detect an event receiver that closes unexpectedly

## Why

Measurement and persistence failures could previously leave gaps without giving the user a clear indication. The dashboard now distinguishes unavailable measurement, unclassified observations, and failed persistence while avoiding window titles, URLs, document names, and raw error details in its public diagnostics.

## Impact

Users see a concise warning when measurement is degraded or activity cannot be saved. Observation and persistence warnings recover automatically after the next successful event or checkpoint.

## Validation

- `cargo test --workspace` (56 tests passed)
- `cargo clippy --workspace --bins --tests --examples -- -D rust_2018_idioms -D warnings`
- `cargo fmt --all -- --check`
- `biome check`
- `git diff --check`

`trunk build` could not run locally because the `wasm32-unknown-unknown` target is not installed; CI will perform the platform build.

Closes #111
