### PR TITLE
chore: pin the Rust toolchain with rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,9 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.changes.outputs.scope != 'none'
-        uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff # 1.95.0
-        with:
-          components: clippy, rustfmt, llvm-tools
+        # The channel, components, and targets come from rust-toolchain.toml so
+        # that CI and local builds always resolve the same toolchain.
+        run: rustup show active-toolchain
 
       - name: Check formatting
         if: steps.changes.outputs.scope != 'none'

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -29,9 +29,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff # 1.95.0
-        with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
+        # The channel and the shared wasm32 target come from rust-toolchain.toml
+        # so that CI, releases, and local builds resolve the same toolchain.
+        run: rustup show active-toolchain
+
+      - name: Install Apple targets (macOS only)
+        if: matrix.platform == 'macos-latest'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Install trunk
         uses: jetli/trunk-action@99496660f5859714859a117b35d888127be572e1 # v0.5.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - `public/`: Static assets served by Trunk. Build artifacts in `dist/` and `target/` remain untracked. CI, release, and hooks live under `.github/`.
 
 ## Build, Test, and Development Commands
+- `rust-toolchain.toml` pins the channel, components, and the `wasm32-unknown-unknown` target. Rustup resolves it automatically, so do not rely on a local `rustup default`; CI and releases read the same file.
 - `cargo tauri dev` – Launch the desktop shell with live-reloaded UI at `http://localhost:1420`.
 - `trunk serve` / `trunk build` – Develop or bundle the Web UI without the shell.
 - `cargo check` • `cargo fmt --all` • `cargo clippy --workspace -- -D warnings` – Full-workspace validation commands; use them after shared manifest or cross-package changes.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ This template should help get you started developing with Tauri and Leptos.
 
 ## Install
 
-To get started, you need to have Rust and the Tauri CLI installed.
+To get started, you need to have [rustup](https://rustup.rs/) and the Tauri CLI installed.
 
 Follow the instructions on the [Tauri website](https://tauri.app/v1/guides/getting-started/prerequisites) to set up your environment.
+
+The Rust toolchain itself is declared in `rust-toolchain.toml`, so rustup installs the correct channel, components, and the `wasm32-unknown-unknown` target on the first build. You do not need to select a toolchain manually.
 
 Once the prerequisites are installed, you can clone the repository and install the dependencies:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy", "llvm-tools"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

ワークスペースがRustツールチェーンを宣言していなかったため、ビルドが各環境の `rustup default` に依存していました。default が `1.89.0` に固定された環境では `cargo tauri dev` が失敗します。

```
error[E0658]: use of unstable library feature `cfg_select`
  --> libsqlite3-sys-0.38.1/build.rs:110:9
error: could not compile `libsqlite3-sys` (build script) due to 2 previous errors
```

`rust-toolchain.toml` でチャネル・コンポーネント・共通ターゲットを宣言し、これを単一の真実にしました。

## Changes

- `rust-toolchain.toml` を追加（`channel = "1.95.0"`、`rustfmt` / `clippy` / `llvm-tools`、`wasm32-unknown-unknown`）
- `ci.yml` と `tauri-release.yml` の `dtolnay/rust-toolchain@<SHA> # 1.95.0` を `rustup show active-toolchain` へ置き換え
- macOSリリースジョブのAppleターゲットは `rustup target add` で明示的に追加
- `AGENTS.md` と `README.md` のセットアップ手順を更新
- 未追跡だった `mise.toml`（`rust = "stable"` のみ）を削除

## Why a single source of truth

`dtolnay/rust-toolchain` はバージョンがref自体に焼き込まれており（action.yml の `env: toolchain: 1.95.0`）、`toolchain` 入力を持たないため `rust-toolchain.toml` を読めません。両方に `1.95.0` を書くとバージョン更新時に2箇所を揃える必要があり、ずれるリスクが残ります。

cargo は常に `rust-toolchain.toml` を優先するため、ワークフロー側の指定を外してファイルに寄せました。これによりRust更新は1ファイルの変更で済み、ローカルとCIが必ず一致します。

macOSのAppleターゲット（`aarch64-apple-darwin` / `x86_64-apple-darwin`）はホスト固有のため、全プラットフォームで共有されるファイルには入れず、リリースジョブ側に残しています。

## Verification

ローカルで `RUSTUP_TOOLCHAIN` の指定なしに以下を確認しました。

- `rustup show active-toolchain` → `1.95.0-aarch64-apple-darwin (overridden by '.../rust-toolchain.toml')`。宣言した3コンポーネントと `wasm32-unknown-unknown` が自動インストールされる
- `cargo check --workspace` → 成功（`libsqlite3-sys` の `cfg_select` が通る）
- `cargo fmt --all -- --check` → 差分なし
- `cargo clippy --workspace --bins --tests --examples -- -D rust_2018_idioms -D warnings` → 警告ゼロ
- `cargo test --workspace` → 56件すべてパス（37 + 4 + 2 + 13）
- `actionlint` → 変更した2ワークフローで指摘なし

## Notes

`channel = "1.95.0"` は従来CIが使っていたバージョンに合わせています。将来のstableへ追従させたい場合は別途方針を決める必要があります。

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
