### PR TITLE
docs: revise ADR 0001 to cover macOS as a v1 target

### DIFF
--- a/docs/adr/0001-track-focused-application-time.md
+++ b/docs/adr/0001-track-focused-application-time.md
@@ -1,7 +1,8 @@
 # ADR 0001: フォーカスアプリの利用時間を計測する / Track focused application usage
 
-- 状態 / Status: 検討中 / Proposed
+- 状態 / Status: 承認済み / Accepted
 - 日付 / Date: 2026-07-27
+- 改訂 / Revised: 2026-08-12
 
 ## コンテキスト / Context
 
@@ -27,51 +28,51 @@ Available information and required permissions vary by operating system, so each
 
 - 基本的な計測対象を、前面でフォーカスされているアプリとする。単にプロセスが起動している時間は利用時間として扱わない。
 - 画面ロック中およびスリープ中の時間を利用時間から除外する。キーボードやマウスの無操作時間だけを根拠としたアイドル除外は行わない。
-- v1 の正式対応 OS と配布対象は Windows とする。Linux と macOS は、将来アダプターを追加できる境界だけを維持する。
+- v1 の正式対応 OS と配布対象は Windows と macOS とする。Linux は正式対応対象外とし、将来アダプターを追加できる境界だけを維持する。
 - 利用時間はアプリ単位で集計する。ブラウザも Chrome、Edge、Firefox などのアプリ単位で扱い、Web サイト、ドメイン、タブ単位には分解しない。
 - ウィンドウタイトルは収集および保存しない。アプリの識別と表示に必要な最小限の情報だけを扱う。
-- 製品体験は macOS のスクリーンタイムを参考にする。ただし、Windows 向けの独立した実装とし、本 ADR の計測範囲とプライバシー方針を優先する。
+- 製品体験は macOS のスクリーンタイムを参考にする。ただし独立した実装とし、本 ADR の計測範囲とプライバシー方針を優先する。
 - v1 は利用時間の計測と可視化に限定する。今日の合計、アプリ別ランキング、時間帯別グラフ、日別・週別の切り替え、過去データをダッシュボードに表示する。
 - 利用制限、通知、カテゴリ分類は v1 に含めない。
 - 利用履歴は端末内だけに保存し、自動削除せず無期限に保持する。サーバー同期を将来導入する場合は、サーバー側の保持期間、同意、削除、セキュリティを別途設計する。
 - 設定画面から全利用履歴を削除できるようにし、実行前に確認を求める。期間指定、アプリ単位の削除、削除後の復元は提供しない。
-- 計測時刻は UTC で保存し、計測時の Windows ローカルタイムゾーンも保存する。日別履歴は計測時点のローカル日付に固定し、週は月曜日から開始する。
-- Windows のフォーカス変更イベントでアプリ切り替えを即時記録し、30 秒ごとに現在のセッションをチェックポイント保存する。内部では秒以下の精度を保持し、画面では分単位で表示する。
-- Windows ログイン時の自動起動は、初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ設定する。後から設定画面で変更できる。
+- 計測時刻は UTC で保存し、計測時の OS ローカルタイムゾーンも保存する。日別履歴は計測時点のローカル日付に固定し、週は月曜日から開始する。
+- OS のフォーカス変更イベントでアプリ切り替えを即時記録し、30 秒ごとに現在のセッションをチェックポイント保存する。ポーリングによる代替は採用しない。内部では秒以下の精度を保持し、画面では分単位で表示する。
+- OS ログイン時の自動起動は、初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ設定する。後から設定画面で変更できる。
 - Time Wise の起動中はトレイに常駐して常時計測する。一時停止・再開機能は提供せず、アプリを終了すると計測を停止する。
-- Time Wise 自身は常に計測対象から除外する。Explorer やタスクマネージャーなど、通常操作できる Windows アプリは原則として計測する。
+- Time Wise 自身は常に計測対象から除外する。Explorer、タスクマネージャー、Finder など、通常操作できる OS 標準アプリは原則として計測する。
 - ユーザー向けの任意アプリ除外および URL・Web サイト単位の除外は提供しない。原理検証や自動テスト用の切り替えは、開発・テスト専用として実装してよい。
 - 同じ製品の複数ウィンドウ、プロセス、ブラウザプロファイルは、一つのアプリとして合算する。画面には製品名と代表アイコンを表示する。
-- 履歴と設定は、現在ログインしている Windows ユーザーのローカル領域へ保存し、別のユーザーアカウントとは共有しない。
+- 履歴と設定は、現在ログインしている OS ユーザーのローカル領域へ保存し、別のユーザーアカウントとは共有しない。
 - アプリ識別子を取得できない時間は「未分類」として総利用時間とアプリ別表示に残す。後から権限が得られても、過去時間を推測で再分類しない。
 - 識別子を取得済みで、表示名やアイコンだけが不足している場合は、後からメタデータを補完して過去履歴の表示へ反映してよい。
-- Windows 11 実機でフォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を受け入れ確認する。
-- GitHub Actions では、Ubuntu で OS 非依存の中核を検証し、Windows でワークスペース全体をビルドおよびテストする。リリース成果物は Windows 向けだけを生成する。
+- Windows 11 実機と macOS 実機の双方で、フォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を受け入れ確認する。
+- GitHub Actions では、Ubuntu で OS 非依存の中核を検証し、Windows と macOS で各プラットフォーム固有コードをビルドおよびテストする。リリース成果物は Windows 向けと macOS 向けを生成する。
 
 ### English
 
 - Measure the application currently focused in the foreground. Do not treat the lifetime of a running process as usage time.
 - Exclude time while the screen is locked or the computer is asleep. Do not exclude time solely because there has been no keyboard or mouse input.
-- Support and distribute v1 for Windows. Preserve boundaries that allow Linux and macOS adapters to be added later.
+- Support and distribute v1 for Windows and macOS. Linux is not an officially supported platform; preserve only the boundary that allows a Linux adapter to be added later.
 - Aggregate usage by application. Treat Chrome, Edge, Firefox, and other browsers as applications; do not break usage down by website, domain, or tab.
 - Do not collect or store window titles. Handle only the minimum information required to identify and display an application.
-- Use macOS Screen Time as a product-experience reference, while building an independent Windows implementation governed by the scope and privacy rules in this ADR.
+- Use macOS Screen Time as a product-experience reference, while building an independent implementation governed by the scope and privacy rules in this ADR.
 - Limit v1 to measurement and visualization. Show today's total, application rankings, an hourly chart, daily and weekly views, and historical data.
 - Exclude usage limits, notifications, and category classification from v1.
 - Store history only on the device, retain it indefinitely, and do not synchronize it with a server. Define separate retention, consent, deletion, and security rules before adding server synchronization.
 - Allow users to delete all usage history from Settings after confirmation. Do not provide deletion by date range or application, or recovery after deletion.
-- Store timestamps in UTC together with the Windows local time zone at measurement time. Assign history permanently to the local date observed at measurement time, and start weeks on Monday.
-- Record application switches immediately from Windows foreground-change events. Checkpoint the current session every 30 seconds. Retain sub-second internal precision and display usage in minutes.
+- Store timestamps in UTC together with the operating-system local time zone at measurement time. Assign history permanently to the local date observed at measurement time, and start weeks on Monday.
+- Record application switches immediately from operating-system foreground-change events. Do not substitute polling. Checkpoint the current session every 30 seconds. Retain sub-second internal precision and display usage in minutes.
 - Explain autostart during onboarding and enable it only after explicit user consent. Allow the setting to be changed later.
 - Measure continuously while Time Wise is running in the system tray. Do not provide pause and resume states. Stop measurement when the application exits.
-- Always exclude Time Wise itself. Measure ordinarily interactive Windows applications such as Explorer and Task Manager by default.
+- Always exclude Time Wise itself. Measure ordinarily interactive system applications such as Explorer, Task Manager, and Finder by default.
 - Do not provide user-facing exclusion rules for applications, URLs, or websites. Development-only switches may be used for proof-of-concept work and automated tests.
 - Combine multiple windows, processes, and browser profiles belonging to the same product into one application. Display one product name and representative icon.
-- Store history and settings in the current Windows user's local data area and do not share them with other Windows accounts.
+- Store history and settings in the currently signed-in operating-system user's local data area and do not share them with other user accounts.
 - Keep time for which no application identifier could be obtained as Unclassified in both totals and application views. Do not infer a historical classification after permissions change.
 - If an identifier was captured but its display name or icon was unavailable, metadata may be added later and reflected in historical views.
-- Perform acceptance testing for focus changes, screen lock, sleep, autostart, and tray behavior on physical Windows 11 hardware.
-- Use GitHub Actions to test the OS-independent core on Ubuntu and the complete workspace on Windows. Produce release artifacts for Windows only.
+- Perform acceptance testing for focus changes, screen lock, sleep, autostart, and tray behavior on both physical Windows 11 and physical macOS hardware.
+- Use GitHub Actions to test the OS-independent core on Ubuntu and to build and test the platform-specific code on Windows and macOS. Produce release artifacts for Windows and macOS.
 
 ## 理由 / Rationale
 
@@ -94,8 +95,8 @@ Available information and required permissions vary by operating system, so each
 ### 日本語
 
 - 現在のプロセス一覧ベースの計測処理を置き換えるか、役割を限定する必要がある。
-- Windows 固有の取得処理をインフラストラクチャ層へ閉じ込め、ドメイン層とアプリケーション層から分離する必要がある。
-- デスクトップアプリとパッケージアプリを、安定した製品単位へ解決する識別処理が必要になる。
+- OS 固有の取得処理をインフラストラクチャ層へ閉じ込め、ドメイン層とアプリケーション層から分離する必要がある。
+- 対応 OS ごとに、デスクトップアプリとパッケージアプリを安定した製品単位へ解決する識別処理が必要になる。
 - ブラウザ内の Web サイト別時間、同じ製品のプロファイル別・ウィンドウ別時間は確認できない。
 - 文書名、メール件名、閲覧ページ名などがウィンドウタイトルを通じて保存されることを防げる一方、タイトルに依存した識別はできない。
 - ロックせずに離席した時間は利用時間に含まれる。将来アイドル時間を推定する場合も、メディア視聴などを誤って除外しない設計が必要になる。
@@ -103,16 +104,17 @@ Available information and required permissions vary by operating system, so each
 - 全履歴削除は取り消せないため、対象と結果を確認画面で明確に伝える必要がある。
 - タイムゾーン変更後も過去の日別集計は安定するが、UTC 時刻に加えて計測時のタイムゾーンまたは確定したローカル日付を永続化する必要がある。
 - イベント購読の停止を検知する必要がある。異常終了時に失われる直近の計測時間は、原則として最大約 30 秒になる。
-- Windows のユーザー切り替え時は、各ユーザーのプロセスと保存領域を独立して扱う必要がある。
+- OS のユーザー切り替え時は、各ユーザーのプロセスと保存領域を独立して扱う必要がある。
 - 未分類時間により総利用時間の欠落を防げるが、識別できなかった過去時間は権限取得後も未分類として残る。
-- OS イベントを伴う動作は CI だけでは保証できないため、Windows 11 実機での受け入れ確認が必要になる。
-- OS 非依存ロジックを Windows 固有コードから分離し、Ubuntu CI でも検証可能にする必要がある。
+- OS イベントを伴う動作は CI だけでは保証できないため、Windows 11 実機と macOS 実機での受け入れ確認が必要になる。
+- OS 非依存ロジックを OS 固有コードから分離し、Ubuntu CI でも検証可能にする必要がある。あわせて、OS 固有コードは各 OS の CI ジョブで検証しなければ `cfg` 境界の破壊を検出できない。
+- 対応 OS が二つになるため、権限モデル、ライフサイクルイベント、アイコン取得の差異をアダプターごとに埋める必要がある。
 
 ### English
 
 - The current process-enumeration recorder must be replaced or given a narrower role.
-- Windows-specific collection must remain in the infrastructure layer, separate from domain and application logic.
-- Desktop and packaged Windows applications require resolution to stable product-level identities.
+- Operating-system-specific collection must remain in the infrastructure layer, separate from domain and application logic.
+- Each supported operating system requires resolution of desktop and packaged applications to stable product-level identities.
 - The product will not report usage by website, browser profile, or individual window.
 - Avoiding window titles prevents storage of document names, email subjects, and page titles, but also prevents title-based identification.
 - Time spent away from an unlocked computer remains usage time. Any future idle-time estimation must avoid excluding passive media consumption.
@@ -120,10 +122,11 @@ Available information and required permissions vary by operating system, so each
 - Deleting all history is irreversible, so the confirmation must clearly communicate its scope and result.
 - Historical daily totals remain stable after time-zone changes, but the system must persist either the measurement-time zone or the finalized local date in addition to UTC timestamps.
 - The recorder must detect stopped event subscriptions. A crash should lose no more than approximately 30 seconds of recent usage under normal conditions.
-- Each signed-in Windows user requires an independent process context and data location.
+- Each signed-in operating-system user requires an independent process context and data location.
 - Unclassified time prevents gaps in the total, but historically unidentified time remains unclassified after permissions change.
-- CI alone cannot validate operating-system events, so acceptance testing on physical Windows 11 hardware is required.
-- OS-independent logic must remain separate from Windows-specific code so it can also be tested in Ubuntu CI.
+- CI alone cannot validate operating-system events, so acceptance testing on both physical Windows 11 and physical macOS hardware is required.
+- OS-independent logic must remain separate from OS-specific code so it can also be tested in Ubuntu CI. In addition, OS-specific code must be verified by a CI job on each operating system, otherwise broken `cfg` boundaries go undetected.
+- Supporting two operating systems requires each adapter to close the gaps between platforms in permission models, lifecycle events, and icon retrieval.
 
 ## 未決事項 / Open questions
 
@@ -138,3 +141,13 @@ Available information and required permissions vary by operating system, so each
 - Detailed session-boundary rules for date changes and momentary focus loss.
 - Display and fallback behavior when OS permissions are unavailable.
 - User-facing errors for permission failures and failed event subscriptions.
+
+## 改訂履歴 / Revision history
+
+### 日本語
+
+- 2026-08-12: 状態を「検討中」から「承認済み」へ変更した。v1 の正式対応 OS と配布対象に macOS を追加し、Windows 固定だった記述を対応 OS 一般の表現へ改めた。受け入れ確認と CI 方針を両 OS に拡張した。計測範囲とプライバシー方針は変更していない。
+
+### English
+
+- 2026-08-12: Changed the status from Proposed to Accepted. Added macOS as an officially supported and distributed v1 platform, and generalized Windows-specific wording to cover every supported operating system. Extended acceptance testing and the CI policy to both platforms. The measurement scope and privacy rules are unchanged.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -48,15 +48,15 @@ A state in which the computer or relevant session is suspended. This period is e
 
 ## 正式対応 OS / Supported operating system
 
-リリース時に計測精度と主要機能を検証し、動作を保証する OS。v1 では Windows を正式対応 OS および配布対象とする。Linux と macOS は、将来アダプターを追加できるアーキテクチャ境界だけを維持する。
+リリース時に計測精度と主要機能を検証し、動作を保証する OS。v1 では Windows と macOS を正式対応 OS および配布対象とする。Linux は正式対応対象外とし、将来アダプターを追加できるアーキテクチャ境界だけを維持する。
 
-An operating system on which measurement accuracy and primary features are validated for release. Windows is the supported and distributed platform for v1. Linux and macOS retain only architectural boundaries for future adapters.
+An operating system on which measurement accuracy and primary features are validated for release. Windows and macOS are the supported and distributed platforms for v1. Linux is not officially supported and retains only an architectural boundary for a future adapter.
 
 ## アプリ / Application
 
-利用時間を集計する単位。Windows 上で安定して取得できる識別情報を基に同一性を判定する。ブラウザはブラウザ自体を一つのアプリとして扱い、Web サイト、ドメイン、タブには分けない。同じ製品の複数ウィンドウ、プロセス、ブラウザプロファイルも一つに合算する。
+利用時間を集計する単位。対応 OS 上で安定して取得できる識別情報を基に同一性を判定する。ブラウザはブラウザ自体を一つのアプリとして扱い、Web サイト、ドメイン、タブには分けない。同じ製品の複数ウィンドウ、プロセス、ブラウザプロファイルも一つに合算する。
 
-The unit used to aggregate usage time, identified from stable information available on Windows. A browser is treated as one application rather than being divided by website, domain, or tab. Multiple windows, processes, and browser profiles belonging to the same product are combined.
+The unit used to aggregate usage time, identified from stable information available on each supported operating system. A browser is treated as one application rather than being divided by website, domain, or tab. Multiple windows, processes, and browser profiles belonging to the same product are combined.
 
 ## アプリ識別情報 / Application identity
 
@@ -72,15 +72,15 @@ Usage time for which no focused-application identifier could be obtained. It is 
 
 ## 受け入れ確認 / Acceptance testing
 
-Windows 11 実機でフォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を確認し、v1 の要件を満たすか判断する手動検証。自動ビルドと自動テストは GitHub Actions で実行する。
+Windows 11 実機と macOS 実機でフォーカス変更、画面ロック、スリープ、自動起動、トレイ動作を確認し、v1 の要件を満たすか判断する手動検証。自動ビルドと自動テストは GitHub Actions で実行する。
 
-Manual validation on physical Windows 11 hardware to determine whether focus changes, screen lock, sleep, autostart, and tray behavior satisfy v1 requirements. Automated builds and tests run in GitHub Actions.
+Manual validation on both physical Windows 11 and physical macOS hardware to determine whether focus changes, screen lock, sleep, autostart, and tray behavior satisfy v1 requirements. Automated builds and tests run in GitHub Actions.
 
 ## ポータブル中核 / Portable core
 
-特定 OS の API に依存しないドメインモデル、利用セッション処理、SQLite 永続化、日別・週別集計。Windows CI に加え、Ubuntu CI でも自動テストする。
+特定 OS の API に依存しないドメインモデル、利用セッション処理、SQLite 永続化、日別・週別集計。Windows CI と macOS CI に加え、Ubuntu CI でも自動テストする。
 
-Domain models, usage-session processing, SQLite persistence, and daily and weekly aggregation that do not depend on a specific operating-system API. The portable core is tested in both Windows and Ubuntu CI.
+Domain models, usage-session processing, SQLite persistence, and daily and weekly aggregation that do not depend on a specific operating-system API. The portable core is tested in Windows, macOS, and Ubuntu CI.
 
 ## 計測と可視化 / Measurement and visualization
 
@@ -90,9 +90,9 @@ The core v1 capability. It records focused-application usage and presents today'
 
 ## ローカル履歴 / Local history
 
-Windows ユーザーアカウントごとの端末内領域に保存された利用履歴。v1 ではサーバーへ送信せず、自動削除も行わず、無期限に保持する。将来サーバー同期を導入する場合は、別の保持規則を定める。
+OS のユーザーアカウントごとの端末内領域に保存された利用履歴。v1 ではサーバーへ送信せず、自動削除も行わず、無期限に保持する。将来サーバー同期を導入する場合は、別の保持規則を定める。
 
-Usage history stored on the device for an individual Windows user account. v1 does not send it to a server, delete it automatically, or share it with other accounts, and retains it indefinitely. Server synchronization will require separate retention rules.
+Usage history stored on the device for an individual operating-system user account. v1 does not send it to a server, delete it automatically, or share it with other accounts, and retains it indefinitely. Server synchronization will require separate retention rules.
 
 ## 全履歴削除 / Delete all history
 
@@ -102,9 +102,9 @@ An operation that deletes all usage history from the device. v1 requires confirm
 
 ## 計測日 / Measurement date
 
-利用時間を日別に集計する日付。計測時点の Windows ローカル日付を使用し、後から端末のタイムゾーンが変わっても過去の計測日は変更しない。
+利用時間を日別に集計する日付。計測時点の OS ローカル日付を使用し、後から端末のタイムゾーンが変わっても過去の計測日は変更しない。
 
-The date used for daily usage aggregation. It is the Windows local date at measurement time and does not change retrospectively when the device's time zone changes.
+The date used for daily usage aggregation. It is the operating-system local date at measurement time and does not change retrospectively when the device's time zone changes.
 
 ## 週 / Week
 
@@ -120,9 +120,9 @@ Periodic persistence of an in-progress usage session. v1 saves a checkpoint ever
 
 ## 自動起動 / Autostart
 
-Windows へのログイン時に Time Wise を起動し、トレイ常駐で計測を始める設定。初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ使用する。後から設定画面で変更できる。
+OS へのログイン時に Time Wise を起動し、トレイ常駐で計測を始める設定。初回セットアップで説明し、ユーザーが明示的に有効化した場合だけ使用する。後から設定画面で変更できる。
 
-A setting that starts Time Wise at Windows sign-in and begins measurement in the system tray. It is explained during onboarding, enabled only with explicit user consent, and can be changed later in Settings.
+A setting that starts Time Wise at operating-system sign-in and begins measurement in the system tray. It is explained during onboarding, enabled only with explicit user consent, and can be changed later in Settings.
 
 ## 計測継続状態 / Continuous measurement
 


### PR DESCRIPTION
## Summary

ADR 0001 は「v1 の正式対応 OS と配布対象は Windows とする」と記録したまま、ステータスが `Proposed`（検討中）で止まっていました。

一方で macOS 実装は既にマージされ、動作しています。

- `src-tauri/src/platform/macos.rs` — `NSWorkspace` によるフォーカスアプリ観測
- `src-tauri/src/app_identity.rs:24` — `macos-bundle:` 安定キーの導出
- `.github/workflows/tauri-release.yml` — macOS×2 構成のリリース成果物

決定が承認されないまま実装が進んだため、ドキュメントとコードが食い違い、どちらが正なのか判断できない状態でした。この不整合を解消します。

## Changes

### `docs/adr/0001-track-focused-application-time.md`

- ステータスを `検討中 / Proposed` から `承認済み / Accepted` へ変更し、改訂日を追加
- v1 の正式対応 OS と配布対象を Windows と macOS に。Linux は正式対応対象外として境界のみ維持
- Windows 固定だった記述を対応OS一般の表現へ一般化
  - タイムゾーン、ローカル保存領域、ユーザー分離
  - フォーカス変更イベント、自動起動
  - 常時計測する OS 標準アプリ（Explorer / タスクマネージャーに Finder を追加）
- 受け入れ確認を Windows 11 実機と macOS 実機の双方へ拡張
- CI方針を #109 の内容に合わせ、「OS固有コードは各OSのCIジョブで検証しなければ `cfg` 境界の破壊を検出できない」ことを影響として明記
- 「対応OSが二つになるため、権限モデル・ライフサイクルイベント・アイコン取得の差異をアダプターごとに埋める必要がある」を影響として追加
- 「ポーリングによる代替は採用しない」を明記（#143 の根拠）
- 改訂履歴セクションを追加

### `docs/glossary.md`

用語集も「仕様の根拠」として参照されており、同じ Windows 限定の記述を持っていたため同一PRで揃えました。

- 正式対応 OS、アプリ、受け入れ確認、ポータブル中核、ローカル履歴、計測日、自動起動 の7項目を修正

## Unchanged

計測範囲とプライバシー方針は変更していません。

- フォーカスアプリ単位の計測
- ウィンドウタイトル・URL・Webサイトの非収集
- 画面ロック中・スリープ中の除外
- ローカル保存のみ、無期限保持、サーバー同期なし
- 利用制限・通知・カテゴリ分類は v1 対象外

## Verification

- `typos docs/` → 指摘なし
- 日本語・英語の両セクションを対応させて更新
- `grep -n Windows docs/` で残存する Windows 記述を確認し、すべて macOS と併記された正当なものであることを確認

## Follow-ups

`ROADMAP.md` は ADR と矛盾しませんが、別の陳腐化があります（`Tauri (v1)` と記載されているが実際は Tauri v2 / 到達点が 2025-10-22 時点 / 完了済み項目が未チェック）。本PRの範囲外とし、別Issueで扱います。

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
