### PR TITLE
fix: exclude locked and asleep time on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ dependencies = [
  "image",
  "objc2 0.6.2",
  "objc2-app-kit",
+ "objc2-foundation 0.3.1",
  "rusqlite",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ windows = { version = "0.62", features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = ["libc", "NSRunningApplication", "NSWorkspace"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -4,21 +4,40 @@ use std::sync::{mpsc, Arc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use objc2::rc::autoreleasepool;
-use objc2_app_kit::NSWorkspace;
+use objc2::rc::{autoreleasepool, Retained};
+use objc2::{define_class, msg_send, sel, AnyThread, DefinedClass};
+use objc2_app_kit::{
+    NSWorkspace, NSWorkspaceDidWakeNotification, NSWorkspaceWillSleepNotification,
+};
+use objc2_foundation::{
+    ns_string, NSDistributedNotificationCenter, NSNotification, NSNotificationCenter, NSObject,
+};
 
-use super::{DesktopEvent, ObservationFailure, ProcessIdentity};
+use super::{DesktopEvent, DesktopEventKind, ObservationFailure, ProcessIdentity};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
-#[derive(Debug)]
 pub struct EventProbe {
     stopped: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
+    lifecycle_observer: Retained<LifecycleObserver>,
+    workspace_center: Retained<NSNotificationCenter>,
+    distributed_center: Retained<NSDistributedNotificationCenter>,
 }
 
 impl Drop for EventProbe {
     fn drop(&mut self) {
+        // SAFETY: The observer is still retained by this probe and is removed
+        // from the same notification centers it was registered with.
+        unsafe {
+            self.workspace_center
+                .removeObserver(&self.lifecycle_observer);
+            self.distributed_center.removeObserver_name_object(
+                &self.lifecycle_observer,
+                None,
+                None,
+            );
+        }
         self.stopped.store(true, Ordering::Release);
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
@@ -26,8 +45,110 @@ impl Drop for EventProbe {
     }
 }
 
+struct LifecycleObserverIvars {
+    sender: mpsc::Sender<DesktopEvent>,
+}
+
+#[derive(Clone, Copy)]
+enum LifecycleSignal {
+    ScreenLocked,
+    ScreenUnlocked,
+    SystemWillSleep,
+    SystemDidWake,
+}
+
+fn lifecycle_event_kind(signal: LifecycleSignal) -> DesktopEventKind {
+    match signal {
+        LifecycleSignal::ScreenLocked => DesktopEventKind::SessionLocked,
+        LifecycleSignal::ScreenUnlocked => DesktopEventKind::SessionUnlocked,
+        LifecycleSignal::SystemWillSleep => DesktopEventKind::Suspended,
+        LifecycleSignal::SystemDidWake => DesktopEventKind::Resumed,
+    }
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements. Notification callbacks
+    // only read the thread-safe channel sender stored in the instance variables.
+    #[unsafe(super(NSObject))]
+    #[name = "TimeWiseLifecycleObserver"]
+    #[ivars = LifecycleObserverIvars]
+    struct LifecycleObserver;
+
+    impl LifecycleObserver {
+        #[unsafe(method(screenLocked:))]
+        fn screen_locked(&self, _notification: &NSNotification) {
+            self.emit(LifecycleSignal::ScreenLocked);
+        }
+
+        #[unsafe(method(screenUnlocked:))]
+        fn screen_unlocked(&self, _notification: &NSNotification) {
+            self.emit(LifecycleSignal::ScreenUnlocked);
+        }
+
+        #[unsafe(method(systemWillSleep:))]
+        fn system_will_sleep(&self, _notification: &NSNotification) {
+            self.emit(LifecycleSignal::SystemWillSleep);
+        }
+
+        #[unsafe(method(systemDidWake:))]
+        fn system_did_wake(&self, _notification: &NSNotification) {
+            self.emit(LifecycleSignal::SystemDidWake);
+        }
+    }
+);
+
+impl LifecycleObserver {
+    fn new(sender: mpsc::Sender<DesktopEvent>) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(LifecycleObserverIvars { sender });
+        // SAFETY: `this` was allocated as LifecycleObserver and its Rust ivars
+        // have been initialized before calling NSObject's initializer.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn emit(&self, signal: LifecycleSignal) {
+        let event = DesktopEvent::lifecycle(lifecycle_event_kind(signal));
+        let _ = self.ivars().sender.send(event);
+    }
+}
+
 pub fn start_event_probe() -> Result<(EventProbe, mpsc::Receiver<DesktopEvent>), String> {
     let (sender, receiver) = mpsc::channel();
+    let lifecycle_observer = LifecycleObserver::new(sender.clone());
+    // SAFETY: The observer implements every registered selector with the
+    // expected single-notification argument. The probe retains the observer
+    // until it removes all registrations during drop.
+    let (workspace_center, distributed_center) = unsafe {
+        let workspace = NSWorkspace::sharedWorkspace();
+        let workspace_center = workspace.notificationCenter();
+        workspace_center.addObserver_selector_name_object(
+            &lifecycle_observer,
+            sel!(systemWillSleep:),
+            Some(NSWorkspaceWillSleepNotification),
+            None,
+        );
+        workspace_center.addObserver_selector_name_object(
+            &lifecycle_observer,
+            sel!(systemDidWake:),
+            Some(NSWorkspaceDidWakeNotification),
+            None,
+        );
+
+        let distributed_center = NSDistributedNotificationCenter::defaultCenter();
+        distributed_center.addObserver_selector_name_object(
+            &lifecycle_observer,
+            sel!(screenLocked:),
+            Some(ns_string!("com.apple.screenIsLocked")),
+            None,
+        );
+        distributed_center.addObserver_selector_name_object(
+            &lifecycle_observer,
+            sel!(screenUnlocked:),
+            Some(ns_string!("com.apple.screenIsUnlocked")),
+            None,
+        );
+        (workspace_center, distributed_center)
+    };
+
     let stopped = Arc::new(AtomicBool::new(false));
     let thread_stopped = stopped.clone();
     let thread = thread::Builder::new()
@@ -52,6 +173,9 @@ pub fn start_event_probe() -> Result<(EventProbe, mpsc::Receiver<DesktopEvent>),
         EventProbe {
             stopped,
             thread: Some(thread),
+            lifecycle_observer,
+            workspace_center,
+            distributed_center,
         },
         receiver,
     ))
@@ -105,4 +229,30 @@ fn observe_frontmost_application() -> DesktopEvent {
         }),
         None,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_signals_map_to_desktop_events() {
+        for (signal, expected) in [
+            (
+                LifecycleSignal::ScreenLocked,
+                DesktopEventKind::SessionLocked,
+            ),
+            (
+                LifecycleSignal::ScreenUnlocked,
+                DesktopEventKind::SessionUnlocked,
+            ),
+            (
+                LifecycleSignal::SystemWillSleep,
+                DesktopEventKind::Suspended,
+            ),
+            (LifecycleSignal::SystemDidWake, DesktopEventKind::Resumed),
+        ] {
+            assert_eq!(lifecycle_event_kind(signal), expected);
+        }
+    }
 }

--- a/src-tauri/src/usage_recorder.rs
+++ b/src-tauri/src/usage_recorder.rs
@@ -264,6 +264,9 @@ impl UsageRecorder {
         let Ok(mut state) = self.state.lock() else {
             return;
         };
+        if matches!(*state, RecorderState::Interrupted) {
+            return;
+        }
         if let RecorderState::Recording(active) = &*state {
             if active.subject == subject {
                 return;
@@ -280,6 +283,9 @@ impl UsageRecorder {
         let Ok(mut state) = self.state.lock() else {
             return;
         };
+        if matches!(*state, RecorderState::Interrupted) {
+            return;
+        }
         if let RecorderState::Recording(active) = &*state {
             self.persist(active, at_utc_ms, "focus_changed");
         }
@@ -520,6 +526,28 @@ mod tests {
             recorder.stop(at(6_000));
             assert_eq!(sink.sessions.lock().unwrap().len(), 2);
         }
+    }
+
+    #[test]
+    fn foreground_changes_are_ignored_while_interrupted() {
+        let (sink, recorder) = recorder();
+        recorder.handle_event(foreground(1_000, "/Applications/Editor.app/Editor"));
+        recorder.handle_event(DesktopEvent {
+            observed_at: at(2_000),
+            kind: DesktopEventKind::SessionLocked,
+            process: None,
+            failure: None,
+        });
+        recorder.handle_event(foreground(
+            2_100,
+            "/System/Library/CoreServices/loginwindow.app/loginwindow",
+        ));
+        recorder.checkpoint(at(3_000));
+
+        let sessions = sink.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].end_reason, "session_locked");
+        assert_eq!(sessions[0].ended_at_utc_ms, 2_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- subscribe to macOS screen lock and unlock notifications
- subscribe to macOS system sleep and wake notifications
- translate those notifications into the existing desktop lifecycle events
- ignore foreground changes while measurement is interrupted so `loginwindow` is not recorded during a lock

## Why

The macOS adapter only emitted foreground changes. The recorder already understood lifecycle interruptions, but it never received them on macOS. In addition, the polling foreground probe could observe `loginwindow` after a lock and restart recording while interrupted.

## Impact

Locked and asleep time is excluded from app usage on macOS. Foreground measurement resumes after the corresponding unlock or wake event and a fresh focus observation.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` (58 passed)
- `cargo clippy --workspace -- -D warnings`
- local `cargo tauri dev` build and launch on macOS

## Manual follow-up

- confirm lock/unlock behavior on a macOS device
- confirm sleep/wake behavior on a macOS device
- confirm `loginwindow` is absent from newly measured usage

Closes #141
