### PR TITLE
fix: enforce a single desktop instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4731,6 +4731,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd707f8c86b4e3004e2c141fa24351f1909ba40ce1b8437e30d5ed5277dd3710"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.16",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +4965,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tempfile",
  "tokio",
  "toml 1.0.4+spec-1.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,13 @@ sysinfo = { version = "0.38" }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 tokio = { version = "1", features = ["time"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false, features = ["libc", "NSRunningApplication", "NSWorkspace"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }
@@ -40,11 +46,6 @@ windows = { version = "0.62", features = [
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
-objc2-app-kit = { version = "0.3", default-features = false, features = ["libc", "NSRunningApplication", "NSWorkspace"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,6 +214,11 @@ pub fn run() {
     let startup_instant = Instant::now();
 
     let builder = tauri::Builder::default()
+        // Register this first so duplicate launches exit before initializing
+        // autostart, windows, tray icons, or measurement workers.
+        .plugin(tauri_plugin_single_instance::init(
+            |_app, _args, _working_directory| {},
+        ))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,

--- a/src-tauri/tests/config.rs
+++ b/src-tauri/tests/config.rs
@@ -104,3 +104,31 @@ fn windows_api_dependency_is_target_specific() {
         assert!(features.contains(&required), "missing feature: {required}");
     }
 }
+
+#[test]
+fn backend_enforces_a_single_desktop_instance() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let manifest_path = format!("{manifest_dir}/Cargo.toml");
+    let data = fs::read_to_string(manifest_path).expect("read Cargo.toml");
+    let manifest: toml::Value = toml::from_str(&data).expect("parse Cargo.toml");
+
+    assert_eq!(
+        manifest["dependencies"]["tauri-plugin-single-instance"].as_str(),
+        Some("2")
+    );
+
+    let lib_path = format!("{manifest_dir}/src/lib.rs");
+    let lib = fs::read_to_string(lib_path).expect("read backend lib.rs");
+    let single_instance = lib
+        .find(".plugin(tauri_plugin_single_instance::init")
+        .expect("single-instance plugin registration");
+    let opener = lib
+        .find(".plugin(tauri_plugin_opener::init")
+        .expect("opener plugin registration");
+    let autostart = lib
+        .find(".plugin(tauri_plugin_autostart::init")
+        .expect("autostart plugin registration");
+
+    assert!(single_instance < opener);
+    assert!(single_instance < autostart);
+}


### PR DESCRIPTION
## Summary

- register Tauri's official single-instance plugin before every other plugin
- prevent duplicate launches from initializing windows, tray icons, autostart, or measurement workers
- add a regression test that protects the dependency and plugin ordering

## Root cause

Two macOS LaunchAgent registrations existed after the launch label changed from `Time Wise` to `time-wise`. Both registrations launched the same executable at login, and the application did not reject a second running instance.

## Impact

Only one Time Wise desktop process remains active even when launchd, a user action, or the development watcher requests another launch.

The local legacy `Time Wise.plist` LaunchAgent was also unloaded and moved to Trash. The current `time-wise.plist` registration remains enabled.

## Validation

- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo test --workspace` (57 passed)
- `cargo clippy --workspace -- -D warnings`
- launched the debug executable a second time and confirmed it exited successfully without creating another process
- triggered repeated development rebuilds and confirmed exactly one Time Wise process remained

Related to #100
