### PR TITLE
fix: stabilize trunk startup with NO_COLOR

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "io.github.umeno3.time-wise",
   "build": {
-    "beforeDevCommand": "trunk serve",
+    "beforeDevCommand": "trunk serve --no-color",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "trunk build",
+    "beforeBuildCommand": "trunk build --no-color",
     "frontendDist": "../dist"
   },
   "app": {

--- a/src-tauri/tests/config.rs
+++ b/src-tauri/tests/config.rs
@@ -43,8 +43,8 @@ fn tauri_window_defaults_and_build_commands() {
     assert_eq!(v["identifier"], "io.github.umeno3.time-wise");
 
     // build commands
-    assert_eq!(v["build"]["beforeDevCommand"], "trunk serve");
-    assert_eq!(v["build"]["beforeBuildCommand"], "trunk build");
+    assert_eq!(v["build"]["beforeDevCommand"], "trunk serve --no-color");
+    assert_eq!(v["build"]["beforeBuildCommand"], "trunk build --no-color");
     assert_eq!(v["build"]["devUrl"], "http://localhost:1420");
 
     // window defaults


### PR DESCRIPTION
## Summary

- pass `--no-color` explicitly to Trunk development and production build commands
- update configuration assertions for the revised commands

## Root cause

When the inherited environment contains `NO_COLOR=1`, Trunk 0.21 interprets the value as a boolean option but only accepts `true` or `false`. The frontend server exits before binding to `localhost:1420`, while the Tauri shell can remain visible and report that it could not connect to the server.

## Impact

Development startup and production builds no longer fail because of an inherited `NO_COLOR=1` value.

## Validation

- `cargo test -p time-wise --test config` (5 passed)
- commit hooks: typos, biome-check, cargo-fmt
