### PR TITLE
fix: apply NO_COLOR to autostart launches

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -211,6 +211,10 @@ fn current_utc_ms() -> u64 {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // GUI launches (including macOS LaunchAgents) do not inherit shell environment
+    // variables. Set this before Tauri starts so its child processes inherit it too.
+    env::set_var("NO_COLOR", "1");
+
     let startup_instant = Instant::now();
 
     let builder = tauri::Builder::default()


### PR DESCRIPTION
## Summary

- set `NO_COLOR=1` at the desktop backend entry point
- apply the setting before Tauri initializes so WebView and other child processes inherit it

## Root cause

GUI launches such as the macOS LaunchAgent do not inherit environment variables configured by the user's shell. As a result, `NO_COLOR` was present for manual shell launches but absent when Time Wise started automatically.

## Impact

Manual and automatic launches now use the same no-color environment for the application process and its children.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` (59 passed)
- pre-push `clippy-tauri` and `test-tauri` hooks