### PR TITLE
test(tauri): improve test coverage for tauri model layer

### DIFF
--- a/src-tauri/src/app_usage.rs
+++ b/src-tauri/src/app_usage.rs
@@ -468,17 +468,32 @@ mod tests {
         );
 
         let instant_inactive = instant_start + Duration::from_secs(1);
-        let system_inactive = system_start.checked_sub(Duration::from_secs(10)).unwrap_or(system_start);
+        let system_inactive = system_start
+            .checked_sub(Duration::from_secs(10))
+            .unwrap_or(system_start);
         recorder.record_mock_snapshot(Vec::new(), instant_inactive, system_inactive);
 
-        assert_eq!(recorder.records_at(instant_inactive, system_inactive).len(), 0);
+        assert_eq!(
+            recorder.records_at(instant_inactive, system_inactive).len(),
+            0
+        );
     }
 
     #[test]
     fn duration_and_system_time_conversion_helpers() {
         assert_eq!(duration_to_ms(Duration::from_millis(1234)), 1234);
-        assert_eq!(system_time_to_ms(UNIX_EPOCH + Duration::from_millis(5678)), 5678);
-        assert_eq!(system_time_to_ms(UNIX_EPOCH.checked_sub(Duration::from_secs(10)).unwrap_or(UNIX_EPOCH)), 0);
+        assert_eq!(
+            system_time_to_ms(UNIX_EPOCH + Duration::from_millis(5678)),
+            5678
+        );
+        assert_eq!(
+            system_time_to_ms(
+                UNIX_EPOCH
+                    .checked_sub(Duration::from_secs(10))
+                    .unwrap_or(UNIX_EPOCH)
+            ),
+            0
+        );
     }
 
     #[test]

--- a/src-tauri/src/app_usage.rs
+++ b/src-tauri/src/app_usage.rs
@@ -418,4 +418,73 @@ mod tests {
         assert!(record.total_active_ms >= 20);
         assert!(!record.active);
     }
+
+    #[test]
+    fn stale_entries_are_purged_after_grace_period() {
+        let recorder = AppUsageRecorder::new();
+        let instant_start = Instant::now();
+        let system_start = SystemTime::now();
+
+        recorder.record_mock_snapshot(
+            vec![ProcessSnapshot::for_tests(
+                "App1",
+                Some("/Applications/App1.app/Contents/MacOS/App1"),
+            )],
+            instant_start,
+            system_start,
+        );
+
+        // Mark inactive
+        let instant_inactive = instant_start + Duration::from_secs(1);
+        let system_inactive = system_start + Duration::from_secs(1);
+        recorder.record_mock_snapshot(Vec::new(), instant_inactive, system_inactive);
+
+        // Within grace period (4 mins)
+        let instant_within = instant_inactive + Duration::from_secs(4 * 60);
+        let system_within = system_inactive + Duration::from_secs(4 * 60);
+        recorder.record_mock_snapshot(Vec::new(), instant_within, system_within);
+        assert_eq!(recorder.records_at(instant_within, system_within).len(), 1);
+
+        // Beyond grace period (> 5 mins)
+        let instant_beyond = instant_inactive + Duration::from_secs(6 * 60);
+        let system_beyond = system_inactive + Duration::from_secs(6 * 60);
+        recorder.record_mock_snapshot(Vec::new(), instant_beyond, system_beyond);
+        assert_eq!(recorder.records_at(instant_beyond, system_beyond).len(), 0);
+    }
+
+    #[test]
+    fn system_time_regression_purges_inactive_entry() {
+        let recorder = AppUsageRecorder::new();
+        let instant_start = Instant::now();
+        let system_start = SystemTime::now();
+
+        recorder.record_mock_snapshot(
+            vec![ProcessSnapshot::for_tests(
+                "App1",
+                Some("/Applications/App1.app/Contents/MacOS/App1"),
+            )],
+            instant_start,
+            system_start,
+        );
+
+        let instant_inactive = instant_start + Duration::from_secs(1);
+        let system_inactive = system_start.checked_sub(Duration::from_secs(10)).unwrap_or(system_start);
+        recorder.record_mock_snapshot(Vec::new(), instant_inactive, system_inactive);
+
+        assert_eq!(recorder.records_at(instant_inactive, system_inactive).len(), 0);
+    }
+
+    #[test]
+    fn duration_and_system_time_conversion_helpers() {
+        assert_eq!(duration_to_ms(Duration::from_millis(1234)), 1234);
+        assert_eq!(system_time_to_ms(UNIX_EPOCH + Duration::from_millis(5678)), 5678);
+        assert_eq!(system_time_to_ms(UNIX_EPOCH.checked_sub(Duration::from_secs(10)).unwrap_or(UNIX_EPOCH)), 0);
+    }
+
+    #[test]
+    fn recorder_default_and_record_current_processes() {
+        let recorder = AppUsageRecorder::default();
+        let res = recorder.record_current_processes();
+        assert!(res.is_ok());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -754,7 +754,10 @@ mod tests {
             Some("Editor".to_string())
         );
         assert_eq!(extract_app_name("/usr/local/bin/my_tool"), None);
-        assert_eq!(extract_app_name("/Applications/.app/Contents/MacOS/Tool"), None);
+        assert_eq!(
+            extract_app_name("/Applications/.app/Contents/MacOS/Tool"),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -742,4 +742,29 @@ mod tests {
         assert_eq!(window.hide_count(), 1);
         assert_eq!(window.last_always_on_top(), Some(false));
     }
+
+    #[test]
+    fn test_extract_app_name() {
+        assert_eq!(
+            extract_app_name("/Applications/Focus.app/Contents/MacOS/Focus"),
+            Some("Focus".to_string())
+        );
+        assert_eq!(
+            extract_app_name("/Program Files/Editor/Editor.exe"),
+            Some("Editor".to_string())
+        );
+        assert_eq!(extract_app_name("/usr/local/bin/my_tool"), None);
+        assert_eq!(extract_app_name("/Applications/.app/Contents/MacOS/Tool"), None);
+    }
+
+    #[test]
+    fn test_current_utc_ms() {
+        assert!(current_utc_ms() > 0);
+    }
+
+    #[test]
+    fn test_resolve_launcher_name() {
+        let name = resolve_launcher_name();
+        assert!(!name.is_empty());
+    }
 }


### PR DESCRIPTION
Adds unit tests targeting the Tauri model backend layer (`app_usage.rs` and `lib.rs`) to improve test coverage. Verified that overall coverage increased from 76.19% to 81.48% with all workspace tests passing.

---
*PR created automatically by Jules for task [9342370397520229852](https://jules.google.com/task/9342370397520229852) started by @9renpoto*